### PR TITLE
Search: doc_type can be a list

### DIFF
--- a/elasticmock/fake_elasticsearch.py
+++ b/elasticmock/fake_elasticsearch.py
@@ -157,8 +157,11 @@ class FakeElasticsearch(Elasticsearch):
         matches = []
         for searchable_index in searchable_indexes:
             for document in self.__documents_dict[searchable_index]:
-                if doc_type is not None and document.get('_type') != doc_type:
-                    continue
+                if doc_type:
+                    if isinstance(doc_type, list) and document.get('_type') not in doc_type:
+                        continue
+                    if isinstance(doc_type, str) and document.get('_type') != doc_type:
+                        continue
                 matches.append(document)
 
         result = {

--- a/setup.py
+++ b/setup.py
@@ -17,8 +17,8 @@ setup(
     include_package_data=True,
     platforms='any',
     install_requires=[
-        'elasticsearch<=1.9.0',
-        'mock<=1.0.1'
+        'elasticsearch',
+        'mock'
     ],
     classifiers=[
         'Environment :: Web Environment',

--- a/tests/test_elasticmock.py
+++ b/tests/test_elasticmock.py
@@ -228,6 +228,20 @@ class TestFakeElasticsearch(unittest.TestCase):
         result = self.es.count(index=['users', 'pcs'])
         self.assertEqual(2, result.get('count'))
 
+    def test_doc_type_can_be_list(self):
+        doc_types = ['1_idx', '2_idx', '3_idx']
+        count_per_doc_type = 3
+
+        for doc_type in doc_types:
+            for _ in range(count_per_doc_type):
+                self.es.index(index=self.index_name, doc_type=doc_type, body={})
+
+        result = self.es.search(doc_type=[doc_types[0]])
+        self.assertEqual(count_per_doc_type, result.get('hits').get('total'))
+
+        result = self.es.search(doc_type=doc_types[:2])
+        self.assertEqual(count_per_doc_type * 2, result.get('hits').get('total'))
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
E.g. https://github.com/elastic/elasticsearch-dsl-py constructs queries like that (and it works against an up-to-date Elasticsearch instance).