### PR TITLE
Implementing new methods for scrolling

### DIFF
--- a/elasticmock/utilities/__init__.py
+++ b/elasticmock/utilities/__init__.py
@@ -2,10 +2,15 @@
 
 import random
 import string
+import base64
 
 DEFAULT_ELASTICSEARCH_ID_SIZE = 20
 CHARSET_FOR_ELASTICSEARCH_ID = string.ascii_letters + string.digits
 
+DEFAULT_ELASTICSEARCH_SEARCHRESULTPHASE_COUNT = 6
 
 def get_random_id(size=DEFAULT_ELASTICSEARCH_ID_SIZE):
     return ''.join(random.choice(CHARSET_FOR_ELASTICSEARCH_ID) for _ in range(size))
+
+def get_random_scroll_id(size=DEFAULT_ELASTICSEARCH_SEARCHRESULTPHASE_COUNT):
+    return base64.b64encode(''.join(get_random_id() for _ in range(size)).encode())


### PR DESCRIPTION
I encountered an issue using your great module. I needed to use and mock scroll methods in order to have a good coverage, so I implemented a few things :

```python
# Method to generate an elasticsearch like scroll_id
def get_random_scroll_id():
    ...

# Method used to scroll over a elasticsearch query results
# without having to query again
def scroll(self, scroll_id, params=None):
    ...
```

When using the `search` method if `params['scroll']` is provided, then you'll have a `result['_scroll_id']` value in the response, that you'll be able to use further on to get next set of hits.
When using the `scroll` parameter, hits count will be limited either to `10` which is elasticsearch default size, either to `params['size']` if provided. Next hits set will be of the same size until no more hits are available for the current query.

New code is unit tested, and existing tests are passing.
Please, give me any feedback if you are forseeing any issue with this :v: