### PR TITLE
Add default value to doc_type in index method as it is by default set to '_doc'

### DIFF
--- a/elasticmock/fake_elasticsearch.py
+++ b/elasticmock/fake_elasticsearch.py
@@ -44,7 +44,7 @@ class FakeElasticsearch(Elasticsearch):
 
     @query_params('consistency', 'op_type', 'parent', 'refresh', 'replication',
                   'routing', 'timeout', 'timestamp', 'ttl', 'version', 'version_type')
-    def index(self, index, doc_type, body, id=None, params=None):
+    def index(self, index, body, doc_type='_doc', id=None, params=None):
         if index not in self.__documents_dict:
             self.__documents_dict[index] = list()
 

--- a/tests/test_elasticmock.py
+++ b/tests/test_elasticmock.py
@@ -27,6 +27,14 @@ class TestFakeElasticsearch(unittest.TestCase):
         self.assertEqual(1, data.get('_version'))
         self.assertEqual(self.index_name, data.get('_index'))
 
+    def test_should_index_document_without_doc_type(self):
+        data = self.es.index(index=self.index_name, body=self.body)
+
+        self.assertEqual('_doc', data.get('_type'))
+        self.assertTrue(data.get('created'))
+        self.assertEqual(1, data.get('_version'))
+        self.assertEqual(self.index_name, data.get('_index'))
+
     def test_should_raise_notfounderror_when_nonindexed_id_is_used(self):
         with self.assertRaises(NotFoundError):
             self.es.get(index=self.index_name, id='1')


### PR DESCRIPTION
Add default value to doc_type in index method as it is by default set to '_doc', as while mocking with es 7.x it fails if we do not add the doc type specifically when calling the index method with the index mock to accept doc_type by default to _doc as with elastic search 7.x the value is set to _doc by default, and when mocking the index method we do have to pass the doc_type as mandatory

https://github.com/vrcmarcos/elasticmock/issues/26