### PR TITLE
Adding fix for updating existing doc using index.

### DIFF
--- a/elasticmock/fake_elasticsearch.py
+++ b/elasticmock/fake_elasticsearch.py
@@ -47,11 +47,15 @@ class FakeElasticsearch(Elasticsearch):
     def index(self, index, body, doc_type='_doc', id=None, params=None):
         if index not in self.__documents_dict:
             self.__documents_dict[index] = list()
+        
+        version = 1
 
         if id is None:
             id = get_random_id()
-
-        version = 1
+        else:
+            doc = self.get(index, id, doc_type)
+            version = doc['_version'] + 1
+            delete_response = self.delete(index, doc_type, id)
 
         self.__documents_dict[index].append({
             '_type': doc_type,

--- a/tests/test_elasticmock.py
+++ b/tests/test_elasticmock.py
@@ -15,6 +15,7 @@ class TestFakeElasticsearch(unittest.TestCase):
         self.index_name = 'test_index'
         self.doc_type = 'doc-Type'
         self.body = {'string': 'content', 'id': 1}
+        self.updated_body = {'string': 'content-updated', 'id': 1}
 
     def test_should_create_fake_elasticsearch_instance(self):
         self.assertIsInstance(self.es, FakeElasticsearch)
@@ -285,6 +286,23 @@ class TestFakeElasticsearch(unittest.TestCase):
         self.assertNotEqual(None, result.get('_scroll_id', None))
         self.assertEqual(10, len(result.get('hits').get('hits')))
         self.assertEqual(100, result.get('hits').get('total'))
+
+    def test_update_existing_doc(self):
+        data = self.es.index(index=self.index_name, doc_type=self.doc_type, body=self.body)
+        document_id = data.get('_id')
+        data = self.es.index(index=self.index_name, id=document_id, doc_type=self.doc_type, body=self.updated_body)
+        target_doc = self.es.get(index=self.index_name, id=document_id)
+
+        expected = {
+            '_type': self.doc_type,
+            '_source': self.updated_body,
+            '_index': self.index_name,
+            '_version': 2,
+            'found': True,
+            '_id': document_id
+        }
+
+        self.assertDictEqual(expected, target_doc)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This PR addresses https://github.com/vrcmarcos/elasticmock/issues/21

As per Elasticsearch's Index API documentation [here](https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-index_.html)

_If the document already exists, updates the document and increments its version._

Adding test case for the same.