### PR TITLE
Allow ignoring of missing documents (404) for get and delete

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-ELASTICMOCK_VERSION='1.6.0'
+ELASTICMOCK_VERSION='1.6.1'
 
 install:
 	pip install -r requirements.txt

--- a/README.md
+++ b/README.md
@@ -177,6 +177,9 @@ python setup.py test
 
 ## Changelog
 
+### 1.6.1:
+
+
 #### 1.6.0:
 - [Implements several basic search types](https://github.com/vrcmarcos/elasticmock/pull/42) (Thanks [@KyKoPho](https://github.com/KyKoPho))
 

--- a/elasticmock/utilities/__init__.py
+++ b/elasticmock/utilities/__init__.py
@@ -16,3 +16,11 @@ def get_random_id(size=DEFAULT_ELASTICSEARCH_ID_SIZE):
 
 def get_random_scroll_id(size=DEFAULT_ELASTICSEARCH_SEARCHRESULTPHASE_COUNT):
     return base64.b64encode(''.join(get_random_id() for _ in range(size)).encode())
+
+
+def extract_ignore_as_iterable(params):
+    """Extracts the value of the ignore parameter as iterable"""
+    ignore = params.get('ignore', ())
+    if isinstance(ignore, int):
+        ignore = (ignore,)
+    return ignore

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 
 import setuptools
 
-__version__ = '1.6.0'
+__version__ = '1.6.1'
 
 # read the contents of your readme file
 from os import path

--- a/tests/fake_elasticsearch/test_delete.py
+++ b/tests/fake_elasticsearch/test_delete.py
@@ -11,6 +11,14 @@ class TestDelete(TestElasticmock):
         with self.assertRaises(NotFoundError):
             self.es.delete(index=INDEX_NAME, doc_type=DOC_TYPE, id=1)
 
+    def test_should_not_raise_exception_when_delete_nonindexed_document_if_ignored(self):
+        target_doc = self.es.delete(index=INDEX_NAME, doc_type=DOC_TYPE, id=1, ignore=404)
+        self.assertFalse(target_doc.get('found'))
+
+    def test_should_not_raise_exception_when_delete_nonindexed_document_if_ignored_list(self):
+        target_doc = self.es.delete(index=INDEX_NAME, doc_type=DOC_TYPE, id=1, ignore=(401, 404))
+        self.assertFalse(target_doc.get('found'))
+
     def test_should_delete_indexed_document(self):
         doc_indexed = self.es.index(index=INDEX_NAME, doc_type=DOC_TYPE, body=BODY)
         search = self.es.search(index=INDEX_NAME)

--- a/tests/fake_elasticsearch/test_get.py
+++ b/tests/fake_elasticsearch/test_get.py
@@ -11,6 +11,14 @@ class TestGet(TestElasticmock):
         with self.assertRaises(NotFoundError):
             self.es.get(index=INDEX_NAME, id='1')
 
+    def test_should_not_raise_notfounderror_when_nonindexed_id_is_used_and_ignored(self):
+        target_doc = self.es.get(index=INDEX_NAME, id='1', ignore=404)
+        self.assertFalse(target_doc.get('found'))
+
+    def test_should_not_raise_notfounderror_when_nonindexed_id_is_used_and_ignored_list(self):
+        target_doc = self.es.get(index=INDEX_NAME, id='1', ignore=(401, 404))
+        self.assertFalse(target_doc.get('found'))
+
     def test_should_get_document_with_id(self):
         data = self.es.index(index=INDEX_NAME, doc_type=DOC_TYPE, body=BODY)
 


### PR DESCRIPTION
## Change
This PR adds functionality to the `get` and `delete` method adhere to the ignore parameter in case the document is not found. Previously a `NotFoundError` was raised. Now we check if we need to ignore 404 errors and if so, simply return an object where the `found` flag is False.

Documentation: https://elasticsearch-py.readthedocs.io/en/latest/api.html#ignore