### PR TITLE
Fix count when doc_type is an empty list

### DIFF
--- a/elasticmock/fake_elasticsearch.py
+++ b/elasticmock/fake_elasticsearch.py
@@ -336,7 +336,7 @@ class FakeElasticsearch(Elasticsearch):
         i = 0
         for searchable_index in searchable_indexes:
             for document in self.__documents_dict[searchable_index]:
-                if doc_type is not None and document.get('_type') != doc_type:
+                if doc_type and document.get('_type') != doc_type:
                     continue
                 i += 1
         result = {

--- a/tests/fake_elasticsearch/test_count.py
+++ b/tests/fake_elasticsearch/test_count.py
@@ -20,3 +20,8 @@ class TestCount(TestElasticmock):
 
         result = self.es.count(index=['users', 'pcs'])
         self.assertEqual(2, result.get('count'))
+
+    def test_should_count_with_empty_doc_types(self):
+        self.es.index(index='index', doc_type=DOC_TYPE, body={'data': 'test'})
+        count = self.es.count(doc_type=[])
+        self.assertEqual(1, count.get('count'))

--- a/tests/fake_elasticsearch/test_count.py
+++ b/tests/fake_elasticsearch/test_count.py
@@ -25,3 +25,9 @@ class TestCount(TestElasticmock):
         self.es.index(index='index', doc_type=DOC_TYPE, body={'data': 'test'})
         count = self.es.count(doc_type=[])
         self.assertEqual(1, count.get('count'))
+
+    def test_should_count_with_doc_types(self):
+        self.es.index(index='index', doc_type=DOC_TYPE, body={'data': 'test1'})
+        self.es.index(index='index', doc_type='different-doc-type', body={'data': 'test2'})
+        count = self.es.count(doc_type=DOC_TYPE)
+        self.assertEqual(1, count.get('count'))


### PR DESCRIPTION
It broke `count` functionality in elasticsearch-dsl