### PR TITLE
Query using nested attributes

### DIFF
--- a/elasticmock/fake_elasticsearch.py
+++ b/elasticmock/fake_elasticsearch.py
@@ -123,32 +123,30 @@ class FakeQueryCondition:
         return return_val
 
     def _compare_value_for_field(self, doc_source, field, value, ignore_case):
-        value = str(value).lower() if ignore_case and isinstance(value, str) \
-            else value
-        doc_val = None
-        if hasattr(doc_source, field):
-            doc_val = getattr(doc_source, field)
-        elif field in doc_source:
-            doc_val = doc_source[field]
+        if ignore_case and isinstance(value, str):
+            value = value.lower()
 
-        if isinstance(doc_val, list):
-            for val in doc_val:
-                val = val if isinstance(val, (int, float, complex)) \
-                    else str(val)
-                if ignore_case and isinstance(val, str):
+        doc_val = doc_source
+        for k in field.split("."):
+            if hasattr(doc_val, k):
+                doc_val = getattr(doc_val, k)
+            elif k in doc_val:
+                doc_val = doc_val[k]
+            else:
+                return False
+
+        if not isinstance(doc_val, list):
+            doc_val = [doc_val]
+
+        for val in doc_val:
+            if not isinstance(val, (int, float, complex)) or val is None:
+                val = str(val)
+                if ignore_case:
                     val = val.lower()
-                if isinstance(val, str) and value in val:
-                    return True
-                if value == val:
-                    return True
-        else:
-            doc_val = doc_val if isinstance(doc_val, (int, float, complex)) \
-                else str(doc_val)
-            if ignore_case and isinstance(doc_val, str):
-                doc_val = doc_val.lower()
-            if isinstance(doc_val, str) and value in doc_val:
+
+            if value == val:
                 return True
-            if value == doc_val:
+            if isinstance(val, str) and value in val:
                 return True
 
         return False

--- a/tests/fake_elasticsearch/test_search.py
+++ b/tests/fake_elasticsearch/test_search.py
@@ -132,3 +132,15 @@ class TestSearch(TestElasticmock):
         self.assertEqual(response['hits']['total'], 3)
         hits = response['hits']['hits']
         self.assertEqual(len(hits), 3)
+
+    def test_query_on_nested_data(self):
+        for i, y in enumerate(['yes', 'no']):
+            self.es.index('index_for_search', doc_type=DOC_TYPE,
+                          body={'id': i, 'data': {'x': i, 'y': y}})
+
+        for term, value, i in [('data.x', 1, 1), ('data.y', 'yes', 0)]:
+            response = self.es.search(index='index_for_search', doc_type=DOC_TYPE,
+                                      body={'query': {'term': {term: value}}})
+            self.assertEqual(1, response['hits']['total'])
+            doc = response['hits']['hits'][0]['_source']
+            self.assertEqual(i, doc['id'])


### PR DESCRIPTION
This allows you to query using nested data, i.e. something like this
```
{"term": {"data.x": 1}}
```

This also fixes cases when you want to filter using

- attribute that isn't present in the data. Originally you'd start with `doc_val = None` and then change it to `"None"` (string) and then you compare it with selected value (including partial match). That mean that string `"one"` would match to missing attribute.
- non-string `value`. that failed on `value in doc_val`