### PR TITLE
Add shards skipped to search and count

### DIFF
--- a/elasticmock/fake_elasticsearch.py
+++ b/elasticmock/fake_elasticsearch.py
@@ -343,6 +343,7 @@ class FakeElasticsearch(Elasticsearch):
             'count': i,
             '_shards': {
                 'successful': 1,
+                'skipped': 0,
                 'failed': 0,
                 'total': 1
             }
@@ -394,6 +395,7 @@ class FakeElasticsearch(Elasticsearch):
             '_shards': {
                 # Simulate indexes with 1 shard each
                 'successful': len(searchable_indexes),
+                'skipped': 0,
                 'failed': 0,
                 'total': len(searchable_indexes)
             },

--- a/tests/fake_elasticsearch/test_count.py
+++ b/tests/fake_elasticsearch/test_count.py
@@ -26,6 +26,11 @@ class TestCount(TestElasticmock):
         count = self.es.count(doc_type=[])
         self.assertEqual(1, count.get('count'))
 
+    def test_should_return_skipped_shards(self):
+        self.es.index(index='index', doc_type=DOC_TYPE, body={'data': 'test'})
+        count = self.es.count(doc_type=[])
+        self.assertEqual(0, count.get('_shards').get('skipped'))
+
     def test_should_count_with_doc_types(self):
         self.es.index(index='index', doc_type=DOC_TYPE, body={'data': 'test1'})
         self.es.index(index='index', doc_type='different-doc-type', body={'data': 'test2'})

--- a/tests/fake_elasticsearch/test_search.py
+++ b/tests/fake_elasticsearch/test_search.py
@@ -16,6 +16,10 @@ class TestSearch(TestElasticmock):
         self.assertEqual(0, search.get('hits').get('total'))
         self.assertListEqual([], search.get('hits').get('hits'))
 
+    def test_should_return_skipped_shards(self):
+        search = self.es.search()
+        self.assertEqual(0, search.get('_shards').get('skipped'))
+
     def test_should_return_all_documents(self):
         index_quantity = 10
         for i in range(0, index_quantity):


### PR DESCRIPTION
This adds a `skipped` member to the `count` and `search` routines, under `_shards`. For example:

```
{'count': 1, '_shards': {'successful': 1, 'skipped': 0, 'failed': 0, 'total': 1}}
```

See https://github.com/vrcmarcos/elasticmock/issues/50