### PR TITLE
Multi lib patch support

### DIFF
--- a/.github/workflows/flake8.yaml
+++ b/.github/workflows/flake8.yaml
@@ -1,0 +1,25 @@
+name: Python package
+
+on: [push]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: '3.x'
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -r requirements.txt
+    - name: Lint with flake8
+      run: |
+        pip install flake8
+        flake8 .
+      continue-on-error: false
+

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -1,0 +1,24 @@
+name: Tox Tests
+
+on: [push]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python: [2.7, 3.9]
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Setup Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python }}
+      - name: Install Tox and any other packages
+        run: pip install tox
+      - name: Run Tox
+        # Run tox using the version of Python in `PATH`
+        run: tox -e py
+

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-ELASTICMOCK_VERSION='1.8.0'
+ELASTICMOCK_VERSION='1.8.0+dd.1'
 
 install:
 	pip3 install -r requirements.txt

--- a/elasticmock/__init__.py
+++ b/elasticmock/__init__.py
@@ -3,7 +3,12 @@
 from functools import wraps
 
 from elasticsearch.client import _normalize_hosts
-from unittest.mock import patch
+from six import PY3
+
+if PY3:
+    from unittest.mock import patch
+else:
+    from mock import patch
 
 from elasticmock.fake_elasticsearch import FakeElasticsearch
 
@@ -12,8 +17,8 @@ ELASTIC_INSTANCES = {}
 
 def _get_elasticmock(hosts=None, *args, **kwargs):
     host = _normalize_hosts(hosts)[0]
-    elastic_key = '{0}:{1}'.format(
-        host.get('host', 'localhost'), host.get('port', 9200)
+    elastic_key = "{0}:{1}".format(
+        host.get("host", "localhost"), host.get("port", 9200)
     )
 
     if elastic_key in ELASTIC_INSTANCES:
@@ -28,7 +33,8 @@ def elasticmock(f):
     @wraps(f)
     def decorated(*args, **kwargs):
         ELASTIC_INSTANCES.clear()
-        with patch('elasticsearch.Elasticsearch', _get_elasticmock):
+        with patch("elasticsearch.Elasticsearch", _get_elasticmock):
             result = f(*args, **kwargs)
         return result
+
     return decorated

--- a/elasticmock/__init__.py
+++ b/elasticmock/__init__.py
@@ -7,12 +7,25 @@ from six import PY3
 
 if PY3:
     from unittest.mock import patch
+
+    from contextlib import ExitStack, contextmanager
+
+    @contextmanager
+    def nested(*contexts):
+        with ExitStack() as stack:
+            for ctx in contexts:
+                stack.enter_context(ctx)
+            yield contexts
 else:
     from mock import patch
+    from contextlib import nested
+
 
 from elasticmock.fake_elasticsearch import FakeElasticsearch
 
 ELASTIC_INSTANCES = {}
+# if you needed to patch elasticsearch6, elasticsearch7 as well
+ELASTIC_CLASSES_TO_PATCH = {"elasticsearch.Elasticsearch", }
 
 
 def _get_elasticmock(hosts=None, *args, **kwargs):
@@ -33,7 +46,7 @@ def elasticmock(f):
     @wraps(f)
     def decorated(*args, **kwargs):
         ELASTIC_INSTANCES.clear()
-        with patch("elasticsearch.Elasticsearch", _get_elasticmock):
+        with nested(*(patch(klass, _get_elasticmock) for klass in ELASTIC_CLASSES_TO_PATCH)):
             result = f(*args, **kwargs)
         return result
 

--- a/elasticmock/behaviour/server_failure.py
+++ b/elasticmock/behaviour/server_failure.py
@@ -19,11 +19,9 @@ def server_failure(f):
     @wraps(f)
     def decorated(*args, **kwargs):
         if __ENABLED:
-            response = {
-                'status_code': 500,
-                'error': 'Internal Server Error'
-            }
+            response = {"status_code": 500, "error": "Internal Server Error"}
         else:
             response = f(*args, **kwargs)
         return response
+
     return decorated

--- a/elasticmock/fake_cluster.py
+++ b/elasticmock/fake_cluster.py
@@ -5,25 +5,31 @@ from elasticsearch.client.utils import query_params
 
 
 class FakeClusterClient(ClusterClient):
-
-    @query_params('level', 'local', 'master_timeout', 'timeout',
-                  'wait_for_active_shards', 'wait_for_nodes',
-                  'wait_for_relocating_shards', 'wait_for_status')
+    @query_params(
+        "level",
+        "local",
+        "master_timeout",
+        "timeout",
+        "wait_for_active_shards",
+        "wait_for_nodes",
+        "wait_for_relocating_shards",
+        "wait_for_status",
+    )
     def health(self, index=None, params=None, headers=None):
         return {
-            'cluster_name': 'testcluster',
-            'status': 'green',
-            'timed_out': False,
-            'number_of_nodes': 1,
-            'number_of_data_nodes': 1,
-            'active_primary_shards': 1,
-            'active_shards': 1,
-            'relocating_shards': 0,
-            'initializing_shards': 0,
-            'unassigned_shards': 1,
-            'delayed_unassigned_shards': 0,
-            'number_of_pending_tasks': 0,
-            'number_of_in_flight_fetch': 0,
-            'task_max_waiting_in_queue_millis': 0,
-            'active_shards_percent_as_number': 50.0
+            "cluster_name": "testcluster",
+            "status": "green",
+            "timed_out": False,
+            "number_of_nodes": 1,
+            "number_of_data_nodes": 1,
+            "active_primary_shards": 1,
+            "active_shards": 1,
+            "relocating_shards": 0,
+            "initializing_shards": 0,
+            "unassigned_shards": 1,
+            "delayed_unassigned_shards": 0,
+            "number_of_pending_tasks": 0,
+            "number_of_in_flight_fetch": 0,
+            "task_max_waiting_in_queue_millis": 0,
+            "active_shards_percent_as_number": 50.0,
         }

--- a/elasticmock/fake_elasticsearch.py
+++ b/elasticmock/fake_elasticsearch.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 import datetime
 import json
-import sys
 from collections import defaultdict
 
 import dateutil.parser
@@ -14,57 +13,59 @@ from elasticsearch.exceptions import NotFoundError, RequestError
 from elasticmock.behaviour.server_failure import server_failure
 from elasticmock.fake_cluster import FakeClusterClient
 from elasticmock.fake_indices import FakeIndicesClient
-from elasticmock.utilities import (extract_ignore_as_iterable, get_random_id,
-    get_random_scroll_id)
+from elasticmock.utilities import (
+    extract_ignore_as_iterable,
+    get_random_id,
+    get_random_scroll_id,
+)
 from elasticmock.utilities.decorator import for_all_methods
-
-PY3 = sys.version_info[0] == 3
-if PY3:
-    unicode = str
+from six import string_types
 
 
 class QueryType:
-    BOOL = 'BOOL'
-    FILTER = 'FILTER'
-    MATCH = 'MATCH'
-    MATCH_ALL = 'MATCH_ALL'
-    TERM = 'TERM'
-    TERMS = 'TERMS'
-    MUST = 'MUST'
-    RANGE = 'RANGE'
-    SHOULD = 'SHOULD'
-    MINIMUM_SHOULD_MATCH = 'MINIMUM_SHOULD_MATCH'
-    MULTI_MATCH = 'MULTI_MATCH'
-    MUST_NOT = 'MUST_NOT'
+    BOOL = "BOOL"
+    FILTER = "FILTER"
+    MATCH = "MATCH"
+    MATCH_ALL = "MATCH_ALL"
+    TERM = "TERM"
+    TERMS = "TERMS"
+    MUST = "MUST"
+    RANGE = "RANGE"
+    SHOULD = "SHOULD"
+    MINIMUM_SHOULD_MATCH = "MINIMUM_SHOULD_MATCH"
+    MULTI_MATCH = "MULTI_MATCH"
+    MUST_NOT = "MUST_NOT"
 
     @staticmethod
     def get_query_type(type_str):
-        if type_str == 'bool':
+        if type_str == "bool":
             return QueryType.BOOL
-        elif type_str == 'filter':
+        elif type_str == "filter":
             return QueryType.FILTER
-        elif type_str == 'match':
+        elif type_str == "match":
             return QueryType.MATCH
-        elif type_str == 'match_all':
+        elif type_str == "match_all":
             return QueryType.MATCH_ALL
-        elif type_str == 'term':
+        elif type_str == "term":
             return QueryType.TERM
-        elif type_str == 'terms':
+        elif type_str == "terms":
             return QueryType.TERMS
-        elif type_str == 'must':
+        elif type_str == "must":
             return QueryType.MUST
-        elif type_str == 'range':
+        elif type_str == "range":
             return QueryType.RANGE
-        elif type_str == 'should':
+        elif type_str == "should":
             return QueryType.SHOULD
-        elif type_str == 'minimum_should_match':
+        elif type_str == "minimum_should_match":
             return QueryType.MINIMUM_SHOULD_MATCH
-        elif type_str == 'multi_match':
+        elif type_str == "multi_match":
             return QueryType.MULTI_MATCH
-        elif type_str == 'must_not':
+        elif type_str == "must_not":
             return QueryType.MUST_NOT
         else:
-            raise NotImplementedError(f'type {type_str} is not implemented for QueryType')
+            raise NotImplementedError(
+                "type {} is not implemented for QueryType".format(type_str)
+            )
 
 
 class MetricType:
@@ -75,7 +76,9 @@ class MetricType:
         if type_str == "cardinality":
             return MetricType.CARDINALITY
         else:
-            raise NotImplementedError(f'type {type_str} is not implemented for MetricType')
+            raise NotImplementedError(
+                "type {} is not implemented for MetricType".format(type_str)
+            )
 
 
 class FakeQueryCondition:
@@ -113,7 +116,9 @@ class FakeQueryCondition:
         elif self.type == QueryType.MUST_NOT:
             return self._evaluate_for_must_not_query_type(document)
         else:
-            raise NotImplementedError('Fake query evaluation not implemented for query type: %s' % self.type)
+            raise NotImplementedError(
+                "Fake query evaluation not implemented for query type: %s" % self.type
+            )
 
     def _evaluate_for_match_query_type(self, document):
         return self._evaluate_for_field(document, True)
@@ -129,33 +134,25 @@ class FakeQueryCondition:
         return False
 
     def _evaluate_for_field(self, document, ignore_case):
-        doc_source = document['_source']
+        doc_source = document["_source"]
         return_val = False
         for field, value in self.condition.items():
             return_val = self._compare_value_for_field(
-                doc_source,
-                field,
-                value,
-                ignore_case
+                doc_source, field, value, ignore_case
             )
             if return_val:
                 break
         return return_val
 
     def _evaluate_for_fields(self, document):
-        doc_source = document['_source']
+        doc_source = document["_source"]
         return_val = False
-        value = self.condition.get('query')
+        value = self.condition.get("query")
         if not value:
             return return_val
-        fields = self.condition.get('fields', [])
+        fields = self.condition.get("fields", [])
         for field in fields:
-            return_val = self._compare_value_for_field(
-                doc_source,
-                field,
-                value,
-                True
-            )
+            return_val = self._compare_value_for_field(doc_source, field, value, True)
             if return_val:
                 break
 
@@ -163,7 +160,7 @@ class FakeQueryCondition:
 
     def _evaluate_for_range_query_type(self, document):
         for field, comparisons in self.condition.items():
-            doc_val = document['_source']
+            doc_val = document["_source"]
             for k in field.split("."):
                 if hasattr(doc_val, k):
                     doc_val = getattr(doc_val, k)
@@ -178,20 +175,20 @@ class FakeQueryCondition:
             for sign, value in comparisons.items():
                 if isinstance(doc_val, datetime.datetime):
                     value = dateutil.parser.isoparse(value)
-                if sign == 'gte':
+                if sign == "gte":
                     if doc_val < value:
                         return False
-                elif sign == 'gt':
+                elif sign == "gt":
                     if doc_val <= value:
                         return False
-                elif sign == 'lte':
+                elif sign == "lte":
                     if doc_val > value:
                         return False
-                elif sign == 'lt':
+                elif sign == "lt":
                     if doc_val >= value:
                         return False
                 else:
-                    raise ValueError(f"Invalid comparison type {sign}")
+                    raise ValueError("Invalid comparison type {}".format(sign))
             return True
 
     def _evaluate_for_compound_query_type(self, document):
@@ -199,8 +196,7 @@ class FakeQueryCondition:
         if isinstance(self.condition, dict):
             for query_type, sub_query in self.condition.items():
                 return_val = FakeQueryCondition(
-                    QueryType.get_query_type(query_type),
-                    sub_query
+                    QueryType.get_query_type(query_type), sub_query
                 ).evaluate(document)
                 if not return_val:
                     return False
@@ -209,7 +205,7 @@ class FakeQueryCondition:
                 for sub_condition_key in sub_condition:
                     return_val = FakeQueryCondition(
                         QueryType.get_query_type(sub_condition_key),
-                        sub_condition[sub_condition_key]
+                        sub_condition[sub_condition_key],
                     ).evaluate(document)
                     if not return_val:
                         return False
@@ -220,8 +216,7 @@ class FakeQueryCondition:
         if isinstance(self.condition, dict):
             for query_type, sub_query in self.condition.items():
                 return_val = FakeQueryCondition(
-                    QueryType.get_query_type(query_type),
-                    sub_query
+                    QueryType.get_query_type(query_type), sub_query
                 ).evaluate(document)
                 if return_val:
                     return False
@@ -230,7 +225,7 @@ class FakeQueryCondition:
                 for sub_condition_key in sub_condition:
                     return_val = FakeQueryCondition(
                         QueryType.get_query_type(sub_condition_key),
-                        sub_condition[sub_condition_key]
+                        sub_condition[sub_condition_key],
                     ).evaluate(document)
                     if return_val:
                         return False
@@ -242,7 +237,7 @@ class FakeQueryCondition:
             for sub_condition_key in sub_condition:
                 return_val = FakeQueryCondition(
                     QueryType.get_query_type(sub_condition_key),
-                    sub_condition[sub_condition_key]
+                    sub_condition[sub_condition_key],
                 ).evaluate(document)
                 if return_val:
                     return True
@@ -257,7 +252,7 @@ class FakeQueryCondition:
 
         doc_val = doc_source
         # Remove boosting
-        field, *_ = field.split("*")
+        field = field.split("*")[0]
         for k in field.split("."):
             if hasattr(doc_val, k):
                 doc_val = getattr(doc_val, k)
@@ -309,32 +304,33 @@ class FakeElasticsearch(Elasticsearch):
     @query_params()
     def info(self, params=None, headers=None):
         return {
-            'status': 200,
-            'cluster_name': 'elasticmock',
-            'version':
-                {
-                    'lucene_version': '4.10.4',
-                    'build_hash': '00f95f4ffca6de89d68b7ccaf80d148f1f70e4d4',
-                    'number': '1.7.5',
-                    'build_timestamp': '2016-02-02T09:55:30Z',
-                    'build_snapshot': False
-                },
-            'name': 'Nightwatch',
-            'tagline': 'You Know, for Search'
+            "status": 200,
+            "cluster_name": "elasticmock",
+            "version": {
+                "lucene_version": "4.10.4",
+                "build_hash": "00f95f4ffca6de89d68b7ccaf80d148f1f70e4d4",
+                "number": "1.7.5",
+                "build_timestamp": "2016-02-02T09:55:30Z",
+                "build_snapshot": False,
+            },
+            "name": "Nightwatch",
+            "tagline": "You Know, for Search",
         }
 
-    @query_params('consistency',
-                  'op_type',
-                  'parent',
-                  'refresh',
-                  'replication',
-                  'routing',
-                  'timeout',
-                  'timestamp',
-                  'ttl',
-                  'version',
-                  'version_type')
-    def index(self, index, body, doc_type='_doc', id=None, params=None, headers=None):
+    @query_params(
+        "consistency",
+        "op_type",
+        "parent",
+        "refresh",
+        "replication",
+        "routing",
+        "timeout",
+        "timestamp",
+        "ttl",
+        "version",
+        "version_type",
+    )
+    def index(self, index, body, doc_type="_doc", id=None, params=None, headers=None):
         if index not in self.__documents_dict:
             self.__documents_dict[index] = list()
 
@@ -344,27 +340,40 @@ class FakeElasticsearch(Elasticsearch):
             id = get_random_id()
         elif self.exists(index, id, doc_type=doc_type, params=params):
             doc = self.get(index, id, doc_type=doc_type, params=params)
-            version = doc['_version'] + 1
+            version = doc["_version"] + 1
             self.delete(index, id, doc_type=doc_type)
 
-        self.__documents_dict[index].append({
-            '_type': doc_type,
-            '_id': id,
-            '_source': body,
-            '_index': index,
-            '_version': version
-        })
+        self.__documents_dict[index].append(
+            {
+                "_type": doc_type,
+                "_id": id,
+                "_source": body,
+                "_index": index,
+                "_version": version,
+            }
+        )
 
         return {
-            '_type': doc_type,
-            '_id': id,
-            'created': True,
-            '_version': version,
-            '_index': index
+            "_type": doc_type,
+            "_id": id,
+            "created": True,
+            "_version": version,
+            "_index": index,
         }
 
-    @query_params('consistency', 'op_type', 'parent', 'refresh', 'replication',
-                  'routing', 'timeout', 'timestamp', 'ttl', 'version', 'version_type')
+    @query_params(
+        "consistency",
+        "op_type",
+        "parent",
+        "refresh",
+        "replication",
+        "routing",
+        "timeout",
+        "timestamp",
+        "ttl",
+        "version",
+        "version_type",
+    )
     def bulk(self, body, index=None, doc_type=None, params=None, headers=None):
         items = []
         errors = False
@@ -373,42 +382,52 @@ class FakeElasticsearch(Elasticsearch):
             if len(raw_line.strip()) > 0:
                 line = json.loads(raw_line)
 
-                if any(action in line for action in ['index', 'create', 'update', 'delete']):
+                if any(
+                    action in line for action in ["index", "create", "update", "delete"]
+                ):
                     action = next(iter(line.keys()))
 
                     version = 1
-                    index = line[action].get('_index') or index
-                    doc_type = line[action].get('_type', "_doc")  # _type is deprecated in 7.x
+                    index = line[action].get("_index") or index
+                    doc_type = line[action].get(
+                        "_type", "_doc"
+                    )  # _type is deprecated in 7.x
 
-                    if action in ['delete', 'update'] and not line[action].get("_id"):
-                        raise RequestError(400, 'action_request_validation_exception', 'missing id')
+                    if action in ["delete", "update"] and not line[action].get("_id"):
+                        raise RequestError(
+                            400, "action_request_validation_exception", "missing id"
+                        )
 
-                    document_id = line[action].get('_id', get_random_id())
+                    document_id = line[action].get("_id", get_random_id())
 
-                    if action == 'delete':
+                    if action == "delete":
                         status, result, error = self._validate_action(
                             action, index, document_id, doc_type, params=params
                         )
-                        item = {action: {
-                            '_type': doc_type,
-                            '_id': document_id,
-                            '_index': index,
-                            '_version': version,
-                            'status': status,
-                        }}
+                        item = {
+                            action: {
+                                "_type": doc_type,
+                                "_id": document_id,
+                                "_index": index,
+                                "_version": version,
+                                "status": status,
+                            }
+                        }
                         if error:
                             errors = True
                             item[action]["error"] = result
                         else:
-                            self.delete(index, document_id, doc_type=doc_type, params=params)
+                            self.delete(
+                                index, document_id, doc_type=doc_type, params=params
+                            )
                             item[action]["result"] = result
                         items.append(item)
 
                     if index not in self.__documents_dict:
                         self.__documents_dict[index] = list()
                 else:
-                    if 'doc' in line and action == 'update':
-                        source = line['doc']
+                    if "doc" in line and action == "update":
+                        source = line["doc"]
                     else:
                         source = line
                     status, result, error = self._validate_action(
@@ -416,146 +435,211 @@ class FakeElasticsearch(Elasticsearch):
                     )
                     item = {
                         action: {
-                            '_type': doc_type,
-                            '_id': document_id,
-                            '_index': index,
-                            '_version': version,
-                            'status': status,
+                            "_type": doc_type,
+                            "_id": document_id,
+                            "_index": index,
+                            "_version": version,
+                            "status": status,
                         }
                     }
                     if not error:
                         item[action]["result"] = result
-                        if self.exists(index, document_id, doc_type=doc_type, params=params):
-                            doc = self.get(index, document_id, doc_type=doc_type, params=params)
-                            version = doc['_version'] + 1
-                            self.delete(index, document_id, doc_type=doc_type, params=params)
+                        if self.exists(
+                            index, document_id, doc_type=doc_type, params=params
+                        ):
+                            doc = self.get(
+                                index, document_id, doc_type=doc_type, params=params
+                            )
+                            version = doc["_version"] + 1
+                            self.delete(
+                                index, document_id, doc_type=doc_type, params=params
+                            )
 
-                        self.__documents_dict[index].append({
-                            '_type': doc_type,
-                            '_id': document_id,
-                            '_source': source,
-                            '_index': index,
-                            '_version': version
-                        })
+                        self.__documents_dict[index].append(
+                            {
+                                "_type": doc_type,
+                                "_id": document_id,
+                                "_source": source,
+                                "_index": index,
+                                "_version": version,
+                            }
+                        )
                     else:
                         errors = True
                         item[action]["error"] = result
                     items.append(item)
-        return {
-            'errors': errors,
-            'items': items
-        }
+        return {"errors": errors, "items": items}
 
     def _validate_action(self, action, index, document_id, doc_type, params=None):
-        if action in ['index', 'update'] and self.exists(index, id=document_id, doc_type=doc_type, params=params):
-            return 200, 'updated', False
-        if action == 'create' and self.exists(index, id=document_id, doc_type=doc_type, params=params):
-            return 409, 'version_conflict_engine_exception', True
-        elif action in ['index', 'create'] and not self.exists(index, id=document_id, doc_type=doc_type, params=params):
-            return 201, 'created', False
-        elif action == "delete" and self.exists(index, id=document_id, doc_type=doc_type, params=params):
-            return 200, 'deleted', False
-        elif action == 'update' and not self.exists(index, id=document_id, doc_type=doc_type, params=params):
-            return 404, 'document_missing_exception', True
-        elif action == 'delete' and not self.exists(index, id=document_id, doc_type=doc_type, params=params):
-            return 404, 'not_found', True
+        if action in ["index", "update"] and self.exists(
+            index, id=document_id, doc_type=doc_type, params=params
+        ):
+            return 200, "updated", False
+        if action == "create" and self.exists(
+            index, id=document_id, doc_type=doc_type, params=params
+        ):
+            return 409, "version_conflict_engine_exception", True
+        elif action in ["index", "create"] and not self.exists(
+            index, id=document_id, doc_type=doc_type, params=params
+        ):
+            return 201, "created", False
+        elif action == "delete" and self.exists(
+            index, id=document_id, doc_type=doc_type, params=params
+        ):
+            return 200, "deleted", False
+        elif action == "update" and not self.exists(
+            index, id=document_id, doc_type=doc_type, params=params
+        ):
+            return 404, "document_missing_exception", True
+        elif action == "delete" and not self.exists(
+            index, id=document_id, doc_type=doc_type, params=params
+        ):
+            return 404, "not_found", True
         else:
-            raise NotImplementedError(f"{action} behaviour hasn't been implemented")
+            raise NotImplementedError(
+                "{} behaviour hasn't been implemented".format(action)
+            )
 
-    @query_params('parent', 'preference', 'realtime', 'refresh', 'routing')
+    @query_params("parent", "preference", "realtime", "refresh", "routing")
     def exists(self, index, id, doc_type=None, params=None, headers=None):
         result = False
         if index in self.__documents_dict:
             for document in self.__documents_dict[index]:
-                if document.get('_id') == id and document.get('_type') == doc_type:
+                if document.get("_id") == id and document.get("_type") == doc_type:
                     result = True
                     break
         return result
 
-    @query_params('_source', '_source_exclude', '_source_include', 'fields',
-                  'parent', 'preference', 'realtime', 'refresh', 'routing', 'version',
-                  'version_type')
-    def get(self, index, id, doc_type='_all', params=None, headers=None):
+    @query_params(
+        "_source",
+        "_source_exclude",
+        "_source_include",
+        "fields",
+        "parent",
+        "preference",
+        "realtime",
+        "refresh",
+        "routing",
+        "version",
+        "version_type",
+    )
+    def get(self, index, id, doc_type="_all", params=None, headers=None):
         ignore = extract_ignore_as_iterable(params)
         result = None
 
         if index in self.__documents_dict:
             for document in self.__documents_dict[index]:
-                if document.get('_id') == id:
-                    if doc_type == '_all':
+                if document.get("_id") == id:
+                    if doc_type == "_all":
                         result = document
                         break
                     else:
-                        if document.get('_type') == doc_type:
+                        if document.get("_type") == doc_type:
                             result = document
                             break
 
         if result:
-            result['found'] = True
+            result["found"] = True
             return result
         elif params and 404 in ignore:
-            return {'found': False}
+            return {"found": False}
         else:
-            error_data = {
-                '_index': index,
-                '_type': doc_type,
-                '_id': id,
-                'found': False
-            }
+            error_data = {"_index": index, "_type": doc_type, "_id": id, "found": False}
             raise NotFoundError(404, json.dumps(error_data))
 
-    @query_params('_source', '_source_exclude', '_source_include',
-                  'preference', 'realtime', 'refresh', 'routing',
-                  'stored_fields')
-    def mget(self, body, index, doc_type='_all', params=None, headers=None):
-        ids = body.get('ids')
+    @query_params(
+        "_source",
+        "_source_exclude",
+        "_source_include",
+        "preference",
+        "realtime",
+        "refresh",
+        "routing",
+        "stored_fields",
+    )
+    def mget(self, body, index, doc_type="_all", params=None, headers=None):
+        ids = body.get("ids")
         results = []
         for id in ids:
             try:
-                results.append(self.get(index, id, doc_type=doc_type,
-                    params=params, headers=headers))
-            except:
+                results.append(
+                    self.get(
+                        index, id, doc_type=doc_type, params=params, headers=headers
+                    )
+                )
+            except Exception:
                 pass
         if not results:
             raise RequestError(
                 400,
-                'action_request_validation_exception',
-                'Validation Failed: 1: no documents to get;'
+                "action_request_validation_exception",
+                "Validation Failed: 1: no documents to get;",
             )
-        return {'docs': results}
+        return {"docs": results}
 
-    @query_params('_source', '_source_exclude', '_source_include', 'parent',
-                  'preference', 'realtime', 'refresh', 'routing', 'version',
-                  'version_type')
+    @query_params(
+        "_source",
+        "_source_exclude",
+        "_source_include",
+        "parent",
+        "preference",
+        "realtime",
+        "refresh",
+        "routing",
+        "version",
+        "version_type",
+    )
     def get_source(self, index, doc_type, id, params=None, headers=None):
         document = self.get(index=index, doc_type=doc_type, id=id, params=params)
-        return document.get('_source')
+        return document.get("_source")
 
-    @query_params('_source', '_source_exclude', '_source_include',
-                  'allow_no_indices', 'analyze_wildcard', 'analyzer', 'default_operator',
-                  'df', 'expand_wildcards', 'explain', 'fielddata_fields', 'fields',
-                  'from_', 'ignore_unavailable', 'lenient', 'lowercase_expanded_terms',
-                  'preference', 'q', 'request_cache', 'routing', 'scroll', 'search_type',
-                  'size', 'sort', 'stats', 'suggest_field', 'suggest_mode',
-                  'suggest_size', 'suggest_text', 'terminate_after', 'timeout',
-                  'track_scores', 'version')
+    @query_params(
+        "_source",
+        "_source_exclude",
+        "_source_include",
+        "allow_no_indices",
+        "analyze_wildcard",
+        "analyzer",
+        "default_operator",
+        "df",
+        "expand_wildcards",
+        "explain",
+        "fielddata_fields",
+        "fields",
+        "from_",
+        "ignore_unavailable",
+        "lenient",
+        "lowercase_expanded_terms",
+        "preference",
+        "q",
+        "request_cache",
+        "routing",
+        "scroll",
+        "search_type",
+        "size",
+        "sort",
+        "stats",
+        "suggest_field",
+        "suggest_mode",
+        "suggest_size",
+        "suggest_text",
+        "terminate_after",
+        "timeout",
+        "track_scores",
+        "version",
+    )
     def count(self, index=None, doc_type=None, body=None, params=None, headers=None):
         searchable_indexes = self._normalize_index_to_list(index)
 
         i = 0
         for searchable_index in searchable_indexes:
             for document in self.__documents_dict[searchable_index]:
-                if doc_type and document.get('_type') != doc_type:
+                if doc_type and document.get("_type") != doc_type:
                     continue
                 i += 1
         result = {
-            'count': i,
-            '_shards': {
-                'successful': 1,
-                'skipped': 0,
-                'failed': 0,
-                'total': 1
-            }
+            "count": i,
+            "_shards": {"successful": 1, "skipped": 0, "failed": 0, "total": 1},
         }
 
         return result
@@ -575,11 +659,11 @@ class FakeElasticsearch(Elasticsearch):
     def msearch(self, body, index=None, doc_type=None, params=None, headers=None):
         def grouped(iterable):
             if len(iterable) % 2 != 0:
-                raise Exception('Malformed body')
+                raise Exception("Malformed body")
             iterator = iter(iterable)
             while True:
                 try:
-                    yield (next(iterator)['index'], next(iterator))
+                    yield (next(iterator)["index"], next(iterator))
                 except StopIteration:
                     break
 
@@ -587,40 +671,69 @@ class FakeElasticsearch(Elasticsearch):
         took = 0
         for ind, query in grouped(body):
             response = self.search(index=ind, body=query)
-            took += response['took']
+            took += response["took"]
             responses.append(response)
-        result = {
-            'took': took,
-            'responses': responses
-        }
+        result = {"took": took, "responses": responses}
         return result
 
-    @query_params('_source', '_source_exclude', '_source_include',
-                  'allow_no_indices', 'analyze_wildcard', 'analyzer', 'default_operator',
-                  'df', 'expand_wildcards', 'explain', 'fielddata_fields', 'fields',
-                  'from_', 'ignore_unavailable', 'lenient', 'lowercase_expanded_terms',
-                  'preference', 'q', 'request_cache', 'routing', 'scroll', 'search_type',
-                  'size', 'sort', 'stats', 'suggest_field', 'suggest_mode',
-                  'suggest_size', 'suggest_text', 'terminate_after', 'timeout',
-                  'track_scores', 'version')
+    @query_params(
+        "_source",
+        "_source_exclude",
+        "_source_include",
+        "allow_no_indices",
+        "analyze_wildcard",
+        "analyzer",
+        "default_operator",
+        "df",
+        "expand_wildcards",
+        "explain",
+        "fielddata_fields",
+        "fields",
+        "from_",
+        "ignore_unavailable",
+        "lenient",
+        "lowercase_expanded_terms",
+        "preference",
+        "q",
+        "request_cache",
+        "routing",
+        "scroll",
+        "search_type",
+        "size",
+        "sort",
+        "stats",
+        "suggest_field",
+        "suggest_mode",
+        "suggest_size",
+        "suggest_text",
+        "terminate_after",
+        "timeout",
+        "track_scores",
+        "version",
+    )
     def search(self, index=None, doc_type=None, body=None, params=None, headers=None):
         searchable_indexes = self._normalize_index_to_list(index)
 
         matches = []
         conditions = []
 
-        if body and 'query' in body:
-            query = body['query']
+        if body and "query" in body:
+            query = body["query"]
             for query_type_str, condition in query.items():
-                conditions.append(self._get_fake_query_condition(query_type_str, condition))
+                conditions.append(
+                    self._get_fake_query_condition(query_type_str, condition)
+                )
         for searchable_index in searchable_indexes:
 
             for document in self.__documents_dict[searchable_index]:
 
                 if doc_type:
-                    if isinstance(doc_type, list) and document.get('_type') not in doc_type:
+                    if (
+                        isinstance(doc_type, list)
+                        and document.get("_type") not in doc_type
+                    ):
                         continue
-                    if isinstance(doc_type, str) and document.get('_type') != doc_type:
+                    if isinstance(doc_type, str) and document.get("_type") != doc_type:
                         continue
                 if conditions:
                     for condition in conditions:
@@ -631,74 +744,84 @@ class FakeElasticsearch(Elasticsearch):
                     matches.append(document)
 
         for match in matches:
-            self._find_and_convert_data_types(match['_source'])
+            self._find_and_convert_data_types(match["_source"])
 
         result = {
-            'hits': {
-                'total': {'value': len(matches), 'relation': 'eq'},
-                'max_score': 1.0
+            "hits": {
+                "total": {"value": len(matches), "relation": "eq"},
+                "max_score": 1.0,
             },
-            '_shards': {
+            "_shards": {
                 # Simulate indexes with 1 shard each
-                'successful': len(searchable_indexes),
-                'skipped': 0,
-                'failed': 0,
-                'total': len(searchable_indexes)
+                "successful": len(searchable_indexes),
+                "skipped": 0,
+                "failed": 0,
+                "total": len(searchable_indexes),
             },
-            'took': 1,
-            'timed_out': False
+            "took": 1,
+            "timed_out": False,
         }
 
         hits = []
         for match in matches:
-            match['_score'] = 1.0
+            match["_score"] = 1.0
             hits.append(match)
 
         # build aggregations
-        if body is not None and 'aggs' in body:
+        if body is not None and "aggs" in body:
             aggregations = {}
 
-            for aggregation, definition in body['aggs'].items():
+            for aggregation, definition in body["aggs"].items():
                 aggregations[aggregation] = {
                     "doc_count_error_upper_bound": 0,
                     "sum_other_doc_count": 0,
-                    "buckets": self.make_aggregation_buckets(definition, matches)
+                    "buckets": self.make_aggregation_buckets(definition, matches),
                 }
 
             if aggregations:
-                result['aggregations'] = aggregations
+                result["aggregations"] = aggregations
 
-        if 'scroll' in params:
-            result['_scroll_id'] = str(get_random_scroll_id())
-            params['size'] = int(params.get('size', 10))
-            params['from'] = int(params.get('from') + params.get('size') if 'from' in params else 0)
-            self.__scrolls[result.get('_scroll_id')] = {
-                'index': index,
-                'doc_type': doc_type,
-                'body': body,
-                'params': params
+        if "scroll" in params:
+            result["_scroll_id"] = str(get_random_scroll_id())
+            params["size"] = int(params.get("size", 10))
+            params["from"] = int(
+                params.get("from") + params.get("size") if "from" in params else 0
+            )
+            self.__scrolls[result.get("_scroll_id")] = {
+                "index": index,
+                "doc_type": doc_type,
+                "body": body,
+                "params": params,
             }
-            hits = hits[params.get('from'):params.get('from') + params.get('size')]
-        elif 'size' in params:
-            hits = hits[:int(params['size'])]
+            hits = hits[params.get("from") : params.get("from") + params.get("size")]
+        elif "size" in params:
+            hits = hits[: int(params["size"])]
 
-        result['hits']['hits'] = hits
+        result["hits"]["hits"] = hits
 
         return result
 
-    @query_params('scroll')
+    @query_params("scroll")
     def scroll(self, scroll_id, params=None, headers=None):
         scroll = self.__scrolls.pop(scroll_id)
         result = self.search(
-            index=scroll.get('index'),
-            doc_type=scroll.get('doc_type'),
-            body=scroll.get('body'),
-            params=scroll.get('params')
+            index=scroll.get("index"),
+            doc_type=scroll.get("doc_type"),
+            body=scroll.get("body"),
+            params=scroll.get("params"),
         )
         return result
 
-    @query_params('consistency', 'parent', 'refresh', 'replication', 'routing',
-                  'timeout', 'version', 'version_type')
+    @query_params(
+        "consistency",
+        "parent",
+        "refresh",
+        "replication",
+        "routing",
+        "timeout",
+        "version",
+        "version_type",
+    )
     def delete(self, index, id, doc_type=None, params=None, headers=None):
 
         found = False
@@ -706,51 +829,56 @@ class FakeElasticsearch(Elasticsearch):
 
         if index in self.__documents_dict:
             for document in self.__documents_dict[index]:
-                if document.get('_id') == id:
+                if document.get("_id") == id:
                     found = True
-                    if doc_type and document.get('_type') != doc_type:
+                    if doc_type and document.get("_type") != doc_type:
                         found = False
                     if found:
                         self.__documents_dict[index].remove(document)
                         break
 
         result_dict = {
-            'found': found,
-            '_index': index,
-            '_type': doc_type,
-            '_id': id,
-            '_version': 1,
+            "found": found,
+            "_index": index,
+            "_type": doc_type,
+            "_id": id,
+            "_version": 1,
         }
 
         if found:
             return result_dict
         elif params and 404 in ignore:
-            return {'found': False}
+            return {"found": False}
         else:
             raise NotFoundError(404, json.dumps(result_dict))
 
-    @query_params('allow_no_indices', 'expand_wildcards', 'ignore_unavailable',
-                  'preference', 'routing')
+    @query_params(
+        "allow_no_indices",
+        "expand_wildcards",
+        "ignore_unavailable",
+        "preference",
+        "routing",
+    )
     def suggest(self, body, index=None, params=None, headers=None):
         if index is not None and index not in self.__documents_dict:
-            raise NotFoundError(404, 'IndexMissingException[[{0}] missing]'.format(index))
+            raise NotFoundError(
+                404, "IndexMissingException[[{0}] missing]".format(index)
+            )
 
         result_dict = {}
         for key, value in body.items():
-            text = value.get('text')
-            suggestion = int(text) + 1 if isinstance(text, int) else '{0}_suggestion'.format(text)
+            text = value.get("text")
+            suggestion = (
+                int(text) + 1
+                if isinstance(text, int)
+                else "{0}_suggestion".format(text)
+            )
             result_dict[key] = [
                 {
-                    'text': text,
-                    'length': 1,
-                    'options': [
-                        {
-                            'text': suggestion,
-                            'freq': 1,
-                            'score': 1.0
-                        }
-                    ],
-                    'offset': 0
+                    "text": text,
+                    "length": 1,
+                    "options": [{"text": suggestion, "freq": 1, "score": 1.0}],
+                    "offset": 0,
                 }
             ]
         return result_dict
@@ -759,7 +887,7 @@ class FakeElasticsearch(Elasticsearch):
         # Ensure to have a list of index
         if index is None:
             searchable_indexes = self.__documents_dict.keys()
-        elif isinstance(index, str) or isinstance(index, unicode):
+        elif isinstance(index, str) or isinstance(index, string_types):
             searchable_indexes = [index]
         elif isinstance(index, list):
             searchable_indexes = index
@@ -770,7 +898,9 @@ class FakeElasticsearch(Elasticsearch):
         # Check index(es) exists
         for searchable_index in searchable_indexes:
             if searchable_index not in self.__documents_dict:
-                raise NotFoundError(404, 'IndexMissingException[[{0}] missing]'.format(searchable_index))
+                raise NotFoundError(
+                    404, "IndexMissingException[[{0}] missing]".format(searchable_index)
+                )
 
         return searchable_indexes
 
@@ -783,12 +913,11 @@ class FakeElasticsearch(Elasticsearch):
                 document[key] = value.isoformat()
 
     def make_aggregation_buckets(self, aggregation, documents):
-        if 'composite' in aggregation:
+        if "composite" in aggregation:
             return self.make_composite_aggregation_buckets(aggregation, documents)
         return []
 
     def make_composite_aggregation_buckets(self, aggregation, documents):
-
         def make_key(doc_source, agg_source):
             attr = list(agg_source.values())[0]["terms"]["field"]
             return doc_source[attr]
@@ -808,7 +937,9 @@ class FakeElasticsearch(Elasticsearch):
                 if metric_type == MetricType.CARDINALITY:
                     value = len(set(data))
                 else:
-                    raise NotImplementedError(f"Metric type '{metric_type}' not implemented")
+                    raise NotImplementedError(
+                        "Metric type '{}' not implemented".format(metric_type)
+                    )
 
                 out[metric_key] = {"value": value}
             return out
@@ -818,7 +949,10 @@ class FakeElasticsearch(Elasticsearch):
         bucket_key_fields = [list(src)[0] for src in agg_sources]
         for document in documents:
             doc_src = document["_source"]
-            key = tuple(make_key(doc_src, agg_src) for agg_src in aggregation["composite"]["sources"])
+            key = tuple(
+                make_key(doc_src, agg_src)
+                for agg_src in aggregation["composite"]["sources"]
+            )
             buckets[key].append(doc_src)
 
         buckets = sorted(((k, v) for k, v in buckets.items()), key=lambda x: x[0])

--- a/elasticmock/fake_indices.py
+++ b/elasticmock/fake_indices.py
@@ -5,24 +5,27 @@ from elasticsearch.client.utils import query_params
 
 
 class FakeIndicesClient(IndicesClient):
-
-    @query_params('master_timeout', 'timeout')
+    @query_params("master_timeout", "timeout")
     def create(self, index, body=None, params=None, headers=None):
         documents_dict = self.__get_documents_dict()
         if index not in documents_dict:
             documents_dict[index] = []
 
-    @query_params('allow_no_indices', 'expand_wildcards', 'ignore_unavailable',
-                  'local')
+    @query_params("allow_no_indices", "expand_wildcards", "ignore_unavailable", "local")
     def exists(self, index, params=None, headers=None):
         return index in self.__get_documents_dict()
 
-    @query_params('allow_no_indices', 'expand_wildcards', 'force',
-                  'ignore_unavailable', 'operation_threading')
+    @query_params(
+        "allow_no_indices",
+        "expand_wildcards",
+        "force",
+        "ignore_unavailable",
+        "operation_threading",
+    )
     def refresh(self, index=None, params=None, headers=None):
         pass
 
-    @query_params('master_timeout', 'timeout')
+    @query_params("master_timeout", "timeout")
     def delete(self, index, params=None, headers=None):
         documents_dict = self.__get_documents_dict()
         if index in documents_dict:

--- a/elasticmock/utilities/__init__.py
+++ b/elasticmock/utilities/__init__.py
@@ -11,16 +11,16 @@ DEFAULT_ELASTICSEARCH_SEARCHRESULTPHASE_COUNT = 6
 
 
 def get_random_id(size=DEFAULT_ELASTICSEARCH_ID_SIZE):
-    return ''.join(random.choice(CHARSET_FOR_ELASTICSEARCH_ID) for _ in range(size))
+    return "".join(random.choice(CHARSET_FOR_ELASTICSEARCH_ID) for _ in range(size))
 
 
 def get_random_scroll_id(size=DEFAULT_ELASTICSEARCH_SEARCHRESULTPHASE_COUNT):
-    return base64.b64encode(''.join(get_random_id() for _ in range(size)).encode())
+    return base64.b64encode("".join(get_random_id() for _ in range(size)).encode())
 
 
 def extract_ignore_as_iterable(params):
     """Extracts the value of the ignore parameter as iterable"""
-    ignore = params.get('ignore', ())
+    ignore = params.get("ignore", ())
     if isinstance(ignore, int):
         ignore = (ignore,)
     return ignore

--- a/elasticmock/utilities/decorator.py
+++ b/elasticmock/utilities/decorator.py
@@ -6,11 +6,12 @@ def for_all_methods(decorators, apply_on_public_only=True):
         for attr in cls.__dict__:
 
             if apply_on_public_only:
-                if attr.startswith('_'):
+                if attr.startswith("_"):
                     continue
 
             if callable(getattr(cls, attr)):
                 for decorator in decorators:
                     setattr(cls, attr, decorator(getattr(cls, attr)))
         return cls
+
     return decorate

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,5 @@
 elasticsearch>=1.9.0,<8.0.0
 ipdb
 python-dateutil
+mock>=2.0.0,<3.0.0
+six

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,2 +1,5 @@
 tox
 parameterized
+pytest
+flake8
+black

--- a/setup.cfg
+++ b/setup.cfg
@@ -4,3 +4,7 @@ python_files=test*.py
 [coverage:run]
 omit =
     */tests/*
+
+[flake8]
+max-line-length = 150
+ignore = E203,W503

--- a/setup.py
+++ b/setup.py
@@ -2,39 +2,42 @@
 
 import setuptools
 
-__version__ = '1.8.0'
+__version__ = "1.8.0+dd.1"
 
 # read the contents of your readme file
 from os import path
+
 this_directory = path.abspath(path.dirname(__file__))
-with open(path.join(this_directory, 'README.md'), encoding='utf-8') as f:
-    long_description = f.read()
+with open(path.join(this_directory, "README.md"), "rb") as f:
+    long_description = f.read().decode("utf-8")
 
 setuptools.setup(
-    name='ElasticMock',
+    name="ElasticMock",
     version=__version__,
-    author='Marcos Cardoso',
-    author_email='vrcmarcos@gmail.com',
-    description='Python Elasticsearch Mock for test purposes',
+    author="Marcos Cardoso",
+    author_email="vrcmarcos@gmail.com",
+    description="Python Elasticsearch Mock for test purposes",
     long_description=long_description,
-    long_description_content_type='text/markdown',
-    url='https://github.com/vrcmarcos/elasticmock',
-    packages=setuptools.find_packages(exclude=('tests')),
+    long_description_content_type="text/markdown",
+    url="https://github.com/vrcmarcos/elasticmock",
+    packages=setuptools.find_packages(exclude=("tests")),
     install_requires=[
-        'elasticsearch',
-        'python-dateutil',
+        "elasticsearch",
+        "python-dateutil",
+        "six",
     ],
     classifiers=[
-        'Environment :: Web Environment',
-        'Intended Audience :: Developers',
-        'Operating System :: OS Independent',
-        'Programming Language :: Python',
-        'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.6',
-        'Programming Language :: Python :: 3.7',
-        'Programming Language :: Python :: 3.8',
-        'Programming Language :: Python :: 3.9',
+        "Environment :: Web Environment",
+        "Intended Audience :: Developers",
+        "Operating System :: OS Independent",
+        "Programming Language :: Python",
+        "Programming Language :: Python :: 2.7",
+        "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
         "License :: OSI Approved :: MIT License",
-        'Topic :: Software Development :: Libraries :: Python Modules'
-    ]
+        "Topic :: Software Development :: Libraries :: Python Modules",
+    ],
 )

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -7,18 +7,19 @@ import elasticsearch
 
 from elasticmock import elasticmock
 
-INDEX_NAME = 'test_index'
-DOC_TYPE = 'doc-Type'
-DOC_ID = 'doc-id'
+INDEX_NAME = "test_index"
+DOC_TYPE = "doc-Type"
+DOC_ID = "doc-id"
 BODY = {
-    'author': 'kimchy',
-    'text': 'Elasticsearch: cool. bonsai cool.',
-    'timestamp': datetime.now(),
+    "author": "kimchy",
+    "text": "Elasticsearch: cool. bonsai cool.",
+    "timestamp": datetime.now(),
 }
 
 
 class TestElasticmock(unittest.TestCase):
-
     @elasticmock
     def setUp(self):
-        self.es = elasticsearch.Elasticsearch(hosts=[{'host': 'localhost', 'port': 9200}])
+        self.es = elasticsearch.Elasticsearch(
+            hosts=[{"host": "localhost", "port": 9200}]
+        )

--- a/tests/fake_cluster/test_health.py
+++ b/tests/fake_cluster/test_health.py
@@ -4,26 +4,25 @@ from tests import TestElasticmock
 
 
 class TestHealth(TestElasticmock):
-
     def test_should_return_health(self):
         health_status = self.es.cluster.health()
 
         expected_health_status = {
-            'cluster_name': 'testcluster',
-            'status': 'green',
-            'timed_out': False,
-            'number_of_nodes': 1,
-            'number_of_data_nodes': 1,
-            'active_primary_shards': 1,
-            'active_shards': 1,
-            'relocating_shards': 0,
-            'initializing_shards': 0,
-            'unassigned_shards': 1,
-            'delayed_unassigned_shards': 0,
-            'number_of_pending_tasks': 0,
-            'number_of_in_flight_fetch': 0,
-            'task_max_waiting_in_queue_millis': 0,
-            'active_shards_percent_as_number': 50.0
+            "cluster_name": "testcluster",
+            "status": "green",
+            "timed_out": False,
+            "number_of_nodes": 1,
+            "number_of_data_nodes": 1,
+            "active_primary_shards": 1,
+            "active_shards": 1,
+            "relocating_shards": 0,
+            "initializing_shards": 0,
+            "unassigned_shards": 1,
+            "delayed_unassigned_shards": 0,
+            "number_of_pending_tasks": 0,
+            "number_of_in_flight_fetch": 0,
+            "task_max_waiting_in_queue_millis": 0,
+            "active_shards_percent_as_number": 50.0,
         }
 
         self.assertDictEqual(expected_health_status, health_status)

--- a/tests/fake_elasticsearch/behaviour/__init__.py
+++ b/tests/fake_elasticsearch/behaviour/__init__.py
@@ -5,6 +5,5 @@ from tests import TestElasticmock
 
 
 class TestElasticmockBehaviour(TestElasticmock):
-
     def tearDown(self):
         behaviour.disable_all()

--- a/tests/fake_elasticsearch/behaviour/test_server_failure.py
+++ b/tests/fake_elasticsearch/behaviour/test_server_failure.py
@@ -6,14 +6,12 @@ from tests import INDEX_NAME, DOC_TYPE, BODY
 
 
 class TestBehaviourServerFailure(TestElasticmockBehaviour):
-
-    def test_should_return_internal_server_error_when_simulate_server_error_is_true(self):
+    def test_should_return_internal_server_error_when_simulate_server_error_is_true(
+        self,
+    ):
         behaviour.server_failure.enable()
         data = self.es.index(index=INDEX_NAME, doc_type=DOC_TYPE, body=BODY)
 
-        expected = {
-            'status_code': 500,
-            'error': 'Internal Server Error'
-        }
+        expected = {"status_code": 500, "error": "Internal Server Error"}
 
         self.assertDictEqual(expected, data)

--- a/tests/fake_elasticsearch/test_bulk.py
+++ b/tests/fake_elasticsearch/test_bulk.py
@@ -6,9 +6,8 @@ from tests import TestElasticmock, INDEX_NAME, DOC_TYPE, BODY, DOC_ID
 
 
 class TestBulk(TestElasticmock):
-
     def test_should_bulk_index_documents_index_creates(self):
-        action = {'index': {'_index': INDEX_NAME, '_type': DOC_TYPE}}
+        action = {"index": {"_index": INDEX_NAME, "_type": DOC_TYPE}}
         action_json = json.dumps(action)
         body_json = json.dumps(BODY, default=str)
         num_of_documents = 10
@@ -17,24 +16,26 @@ class TestBulk(TestElasticmock):
         for count in range(0, num_of_documents):
             lines.append(action_json)
             lines.append(body_json)
-        body = '\n'.join(lines)
+        body = "\n".join(lines)
 
         data = self.es.bulk(body=body)
-        items = data.get('items')
+        items = data.get("items")
 
-        self.assertFalse(data.get('errors'))
+        self.assertFalse(data.get("errors"))
         self.assertEqual(num_of_documents, len(items))
 
         for item in items:
-            index = item.get('index')
-            self.assertEqual(DOC_TYPE, index.get('_type'))
-            self.assertEqual(INDEX_NAME, index.get('_index'))
-            self.assertEqual('created', index.get('result'))
-            self.assertEqual(201, index.get('status'))
+            index = item.get("index")
+            self.assertEqual(DOC_TYPE, index.get("_type"))
+            self.assertEqual(INDEX_NAME, index.get("_index"))
+            self.assertEqual("created", index.get("result"))
+            self.assertEqual(201, index.get("status"))
 
     def test_should_bulk_index_documents_create_creates(self):
-        create_action = {'create': {'_index': INDEX_NAME, '_type': DOC_TYPE}}
-        create_with_id = {'create': {'_index': INDEX_NAME, '_type': DOC_TYPE, '_id': DOC_ID}}
+        create_action = {"create": {"_index": INDEX_NAME, "_type": DOC_TYPE}}
+        create_with_id = {
+            "create": {"_index": INDEX_NAME, "_type": DOC_TYPE, "_id": DOC_ID}
+        }
         actions = [
             json.dumps(create_action),
             json.dumps(BODY, default=str),
@@ -46,27 +47,29 @@ class TestBulk(TestElasticmock):
             json.dumps(create_with_id),
             json.dumps(BODY, default=str),
         ]
-        body = '\n'.join(actions)
+        body = "\n".join(actions)
 
         data = self.es.bulk(body=body)
 
-        items = data.get('items')
+        items = data.get("items")
 
-        self.assertTrue(data.get('errors'))
+        self.assertTrue(data.get("errors"))
         self.assertEqual(4, len(items))
 
         last_item = items.pop()
-        self.assertEqual(last_item['create']['error'], 'version_conflict_engine_exception')
-        self.assertEqual(last_item['create']['status'], 409)
+        self.assertEqual(
+            last_item["create"]["error"], "version_conflict_engine_exception"
+        )
+        self.assertEqual(last_item["create"]["status"], 409)
         for item in items:
-            index = item.get('create')
-            self.assertEqual(DOC_TYPE, index.get('_type'))
-            self.assertEqual(INDEX_NAME, index.get('_index'))
-            self.assertEqual('created', index.get('result'))
-            self.assertEqual(201, index.get('status'))
+            index = item.get("create")
+            self.assertEqual(DOC_TYPE, index.get("_type"))
+            self.assertEqual(INDEX_NAME, index.get("_index"))
+            self.assertEqual("created", index.get("result"))
+            self.assertEqual(201, index.get("status"))
 
     def test_should_bulk_index_documents_index_updates(self):
-        action = {'index': {'_index': INDEX_NAME, '_id': DOC_ID, '_type': DOC_TYPE}}
+        action = {"index": {"_index": INDEX_NAME, "_id": DOC_ID, "_type": DOC_TYPE}}
         action_json = json.dumps(action)
         body_json = json.dumps(BODY, default=str)
         num_of_documents = 10
@@ -75,12 +78,12 @@ class TestBulk(TestElasticmock):
         for count in range(0, num_of_documents):
             lines.append(action_json)
             lines.append(body_json)
-        body = '\n'.join(lines)
+        body = "\n".join(lines)
 
         data = self.es.bulk(body=body)
-        items = data.get('items')
+        items = data.get("items")
 
-        self.assertFalse(data.get('errors'))
+        self.assertFalse(data.get("errors"))
         self.assertEqual(num_of_documents, len(items))
 
         first_item = items.pop(0)
@@ -88,31 +91,31 @@ class TestBulk(TestElasticmock):
         self.assertEqual(first_item["index"]["result"], "created")
 
         for item in items:
-            index = item.get('index')
-            self.assertEqual(DOC_TYPE, index.get('_type'))
-            self.assertEqual(INDEX_NAME, index.get('_index'))
-            self.assertEqual('updated', index.get('result'))
-            self.assertEqual(200, index.get('status'))
+            index = item.get("index")
+            self.assertEqual(DOC_TYPE, index.get("_type"))
+            self.assertEqual(INDEX_NAME, index.get("_index"))
+            self.assertEqual("updated", index.get("result"))
+            self.assertEqual(200, index.get("status"))
 
     def test_should_bulk_index_documents_update_updates(self):
-        action = {'update': {'_index': INDEX_NAME, '_id': DOC_ID, '_type': DOC_TYPE}}
+        action = {"update": {"_index": INDEX_NAME, "_id": DOC_ID, "_type": DOC_TYPE}}
         action_json = json.dumps(action)
         create_action_json = json.dumps(
-            {'create': {'_index': INDEX_NAME, '_id': DOC_ID, '_type': DOC_TYPE}}
+            {"create": {"_index": INDEX_NAME, "_id": DOC_ID, "_type": DOC_TYPE}}
         )
-        body_json = json.dumps({'doc': BODY}, default=str)
+        body_json = json.dumps({"doc": BODY}, default=str)
         num_of_documents = 4
 
         lines = [create_action_json, json.dumps(BODY, default=str)]
         for count in range(0, num_of_documents):
             lines.append(action_json)
             lines.append(body_json)
-        body = '\n'.join(lines)
+        body = "\n".join(lines)
 
         data = self.es.bulk(body=body)
-        items = data.get('items')
+        items = data.get("items")
 
-        self.assertFalse(data.get('errors'))
+        self.assertFalse(data.get("errors"))
         self.assertEqual(num_of_documents + 1, len(items))
 
         first_item = items.pop(0)
@@ -120,17 +123,19 @@ class TestBulk(TestElasticmock):
         self.assertEqual(first_item["create"]["result"], "created")
 
         for item in items:
-            index = item.get('update')
-            self.assertEqual(DOC_TYPE, index.get('_type'))
-            self.assertEqual(INDEX_NAME, index.get('_index'))
-            self.assertEqual('updated', index.get('result'))
-            self.assertEqual(200, index.get('status'))
+            index = item.get("update")
+            self.assertEqual(DOC_TYPE, index.get("_type"))
+            self.assertEqual(INDEX_NAME, index.get("_index"))
+            self.assertEqual("updated", index.get("result"))
+            self.assertEqual(200, index.get("status"))
 
     def test_should_bulk_index_documents_delete_deletes(self):
-        delete_action = {'delete': {'_index': INDEX_NAME, '_id': DOC_ID, '_type': DOC_TYPE}}
+        delete_action = {
+            "delete": {"_index": INDEX_NAME, "_id": DOC_ID, "_type": DOC_TYPE}
+        }
         delete_action_json = json.dumps(delete_action)
         create_action_json = json.dumps(
-            {'create': {'_index': INDEX_NAME, '_id': DOC_ID, '_type': DOC_TYPE}}
+            {"create": {"_index": INDEX_NAME, "_id": DOC_ID, "_type": DOC_TYPE}}
         )
 
         lines = [
@@ -138,25 +143,25 @@ class TestBulk(TestElasticmock):
             json.dumps(BODY, default=str),
             delete_action_json,
         ]
-        body = '\n'.join(lines)
+        body = "\n".join(lines)
 
         data = self.es.bulk(body=body)
-        items = data.get('items')
+        items = data.get("items")
 
-        self.assertFalse(data.get('errors'))
+        self.assertFalse(data.get("errors"))
         self.assertEqual(2, len(items))
 
         first_item = items.pop(0)
         self.assertEqual(first_item["create"]["status"], 201)
         self.assertEqual(first_item["create"]["result"], "created")
-        self.assertEqual(first_item["create"]['_type'], DOC_TYPE)
-        self.assertEqual(first_item["create"]['_id'], DOC_ID)
+        self.assertEqual(first_item["create"]["_type"], DOC_TYPE)
+        self.assertEqual(first_item["create"]["_id"], DOC_ID)
 
         second_item = items.pop(0)
         self.assertEqual(second_item["delete"]["status"], 200)
         self.assertEqual(second_item["delete"]["result"], "deleted")
-        self.assertEqual(second_item["delete"]['_type'], DOC_TYPE)
-        self.assertEqual(second_item["delete"]['_id'], DOC_ID)
+        self.assertEqual(second_item["delete"]["_type"], DOC_TYPE)
+        self.assertEqual(second_item["delete"]["_id"], DOC_ID)
 
     def test_should_bulk_index_documents_mixed_actions(self):
         doc_body = json.dumps(BODY, default=str)
@@ -164,48 +169,127 @@ class TestBulk(TestElasticmock):
         doc_id_1 = 1
         doc_id_2 = 2
         actions = [
-            json.dumps({'create': {'_index': INDEX_NAME, '_type': DOC_TYPE, '_id': doc_id_1}}),
+            json.dumps(
+                {"create": {"_index": INDEX_NAME, "_type": DOC_TYPE, "_id": doc_id_1}}
+            ),
             doc_body,  # 201
-            json.dumps({'create': {'_index': INDEX_NAME, '_type': DOC_TYPE, '_id': doc_id_1}}),
+            json.dumps(
+                {"create": {"_index": INDEX_NAME, "_type": DOC_TYPE, "_id": doc_id_1}}
+            ),
             doc_body,  # 409
-            json.dumps({'index': {'_index': INDEX_NAME, '_type': DOC_TYPE, '_id': doc_id_2}}),
+            json.dumps(
+                {"index": {"_index": INDEX_NAME, "_type": DOC_TYPE, "_id": doc_id_2}}
+            ),
             doc_body,  # 201
-            json.dumps({'index': {'_index': INDEX_NAME, '_type': DOC_TYPE, '_id': doc_id_2}}),
+            json.dumps(
+                {"index": {"_index": INDEX_NAME, "_type": DOC_TYPE, "_id": doc_id_2}}
+            ),
             doc_body,  # 200
-            json.dumps({'update': {'_index': INDEX_NAME, '_type': DOC_TYPE, '_id': doc_id_1}}),
+            json.dumps(
+                {"update": {"_index": INDEX_NAME, "_type": DOC_TYPE, "_id": doc_id_1}}
+            ),
             doc_body,  # 200
-            json.dumps({'delete': {'_index': INDEX_NAME, '_type': DOC_TYPE, '_id': doc_id_1}}),
+            json.dumps(
+                {"delete": {"_index": INDEX_NAME, "_type": DOC_TYPE, "_id": doc_id_1}}
+            ),
             # 200
-            json.dumps({'update': {'_index': INDEX_NAME, '_type': DOC_TYPE, '_id': doc_id_1}}),
+            json.dumps(
+                {"update": {"_index": INDEX_NAME, "_type": DOC_TYPE, "_id": doc_id_1}}
+            ),
             doc_body,  # 404
-            json.dumps({'delete': {'_index': INDEX_NAME, '_type': DOC_TYPE, '_id': doc_id_1}}),
+            json.dumps(
+                {"delete": {"_index": INDEX_NAME, "_type": DOC_TYPE, "_id": doc_id_1}}
+            ),
             # 404
         ]
-        body = '\n'.join(actions)
+        body = "\n".join(actions)
 
         data = self.es.bulk(body=body)
 
         expected = [
-            {'create': {'_type': DOC_TYPE, '_id': 1, '_index': INDEX_NAME,
-                        '_version': 1, 'status': 201, 'result': 'created'}},
-            {'create': {'_type': DOC_TYPE, '_id': 1, '_index': INDEX_NAME,
-                        '_version': 1, 'status': 409,
-                        'error': 'version_conflict_engine_exception'}},
-            {'index': {'_type': DOC_TYPE, '_id': 2, '_index': INDEX_NAME,
-                       '_version': 1, 'status': 201, 'result': 'created'}},
-            {'index': {'_type': DOC_TYPE, '_id': 2, '_index': INDEX_NAME,
-                       '_version': 1, 'status': 200, 'result': 'updated'}},
-            {'update': {'_type': DOC_TYPE, '_id': 1, '_index': INDEX_NAME,
-                        '_version': 1, 'status': 200, 'result': 'updated'}},
-            {'delete': {'_type': DOC_TYPE, '_id': 1, '_index': INDEX_NAME,
-                        '_version': 1, 'result': 'deleted', 'status': 200}},
-            {'update': {'_type': DOC_TYPE, '_id': 1, '_index': INDEX_NAME,
-                        '_version': 1, 'status': 404, 'error': 'document_missing_exception'}},
-            {'delete': {'_type': DOC_TYPE, '_id': 1, '_index': INDEX_NAME,
-                        '_version': 1, 'error': 'not_found', 'status': 404}},
-            ]
+            {
+                "create": {
+                    "_type": DOC_TYPE,
+                    "_id": 1,
+                    "_index": INDEX_NAME,
+                    "_version": 1,
+                    "status": 201,
+                    "result": "created",
+                }
+            },
+            {
+                "create": {
+                    "_type": DOC_TYPE,
+                    "_id": 1,
+                    "_index": INDEX_NAME,
+                    "_version": 1,
+                    "status": 409,
+                    "error": "version_conflict_engine_exception",
+                }
+            },
+            {
+                "index": {
+                    "_type": DOC_TYPE,
+                    "_id": 2,
+                    "_index": INDEX_NAME,
+                    "_version": 1,
+                    "status": 201,
+                    "result": "created",
+                }
+            },
+            {
+                "index": {
+                    "_type": DOC_TYPE,
+                    "_id": 2,
+                    "_index": INDEX_NAME,
+                    "_version": 1,
+                    "status": 200,
+                    "result": "updated",
+                }
+            },
+            {
+                "update": {
+                    "_type": DOC_TYPE,
+                    "_id": 1,
+                    "_index": INDEX_NAME,
+                    "_version": 1,
+                    "status": 200,
+                    "result": "updated",
+                }
+            },
+            {
+                "delete": {
+                    "_type": DOC_TYPE,
+                    "_id": 1,
+                    "_index": INDEX_NAME,
+                    "_version": 1,
+                    "result": "deleted",
+                    "status": 200,
+                }
+            },
+            {
+                "update": {
+                    "_type": DOC_TYPE,
+                    "_id": 1,
+                    "_index": INDEX_NAME,
+                    "_version": 1,
+                    "status": 404,
+                    "error": "document_missing_exception",
+                }
+            },
+            {
+                "delete": {
+                    "_type": DOC_TYPE,
+                    "_id": 1,
+                    "_index": INDEX_NAME,
+                    "_version": 1,
+                    "error": "not_found",
+                    "status": 404,
+                }
+            },
+        ]
 
-        actual = data.get('items')
+        actual = data.get("items")
 
-        self.assertTrue(data.get('errors'))
+        self.assertTrue(data.get("errors"))
         self.assertEqual(actual, expected)

--- a/tests/fake_elasticsearch/test_count.py
+++ b/tests/fake_elasticsearch/test_count.py
@@ -4,35 +4,40 @@ from tests import TestElasticmock, DOC_TYPE
 
 
 class TestCount(TestElasticmock):
-
     def test_should_return_count_for_indexed_documents_on_index(self):
         index_quantity = 0
         for i in range(0, index_quantity):
-            self.es.index(index='index_{0}'.format(i), doc_type=DOC_TYPE, body={'data': 'test_{0}'.format(i)})
+            self.es.index(
+                index="index_{0}".format(i),
+                doc_type=DOC_TYPE,
+                body={"data": "test_{0}".format(i)},
+            )
 
         count = self.es.count()
-        self.assertEqual(index_quantity, count.get('count'))
+        self.assertEqual(index_quantity, count.get("count"))
 
     def test_should_count_in_multiple_indexes(self):
-        self.es.index(index='groups', doc_type='groups', body={'budget': 1000})
-        self.es.index(index='users', doc_type='users', body={'name': 'toto'})
-        self.es.index(index='pcs', doc_type='pcs', body={'model': 'macbook'})
+        self.es.index(index="groups", doc_type="groups", body={"budget": 1000})
+        self.es.index(index="users", doc_type="users", body={"name": "toto"})
+        self.es.index(index="pcs", doc_type="pcs", body={"model": "macbook"})
 
-        result = self.es.count(index=['users', 'pcs'])
-        self.assertEqual(2, result.get('count'))
+        result = self.es.count(index=["users", "pcs"])
+        self.assertEqual(2, result.get("count"))
 
     def test_should_count_with_empty_doc_types(self):
-        self.es.index(index='index', doc_type=DOC_TYPE, body={'data': 'test'})
+        self.es.index(index="index", doc_type=DOC_TYPE, body={"data": "test"})
         count = self.es.count(doc_type=[])
-        self.assertEqual(1, count.get('count'))
+        self.assertEqual(1, count.get("count"))
 
     def test_should_return_skipped_shards(self):
-        self.es.index(index='index', doc_type=DOC_TYPE, body={'data': 'test'})
+        self.es.index(index="index", doc_type=DOC_TYPE, body={"data": "test"})
         count = self.es.count(doc_type=[])
-        self.assertEqual(0, count.get('_shards').get('skipped'))
+        self.assertEqual(0, count.get("_shards").get("skipped"))
 
     def test_should_count_with_doc_types(self):
-        self.es.index(index='index', doc_type=DOC_TYPE, body={'data': 'test1'})
-        self.es.index(index='index', doc_type='different-doc-type', body={'data': 'test2'})
+        self.es.index(index="index", doc_type=DOC_TYPE, body={"data": "test1"})
+        self.es.index(
+            index="index", doc_type="different-doc-type", body={"data": "test2"}
+        )
         count = self.es.count(doc_type=DOC_TYPE)
-        self.assertEqual(1, count.get('count'))
+        self.assertEqual(1, count.get("count"))

--- a/tests/fake_elasticsearch/test_delete.py
+++ b/tests/fake_elasticsearch/test_delete.py
@@ -6,35 +6,42 @@ from tests import TestElasticmock, INDEX_NAME, DOC_TYPE, BODY
 
 
 class TestDelete(TestElasticmock):
-
     def test_should_raise_exception_when_delete_nonindexed_document(self):
         with self.assertRaises(NotFoundError):
             self.es.delete(index=INDEX_NAME, doc_type=DOC_TYPE, id=1)
 
-    def test_should_not_raise_exception_when_delete_nonindexed_document_if_ignored(self):
-        target_doc = self.es.delete(index=INDEX_NAME, doc_type=DOC_TYPE, id=1, ignore=404)
-        self.assertFalse(target_doc.get('found'))
+    def test_should_not_raise_exception_when_delete_nonindexed_document_if_ignored(
+        self,
+    ):
+        target_doc = self.es.delete(
+            index=INDEX_NAME, doc_type=DOC_TYPE, id=1, ignore=404
+        )
+        self.assertFalse(target_doc.get("found"))
 
-    def test_should_not_raise_exception_when_delete_nonindexed_document_if_ignored_list(self):
-        target_doc = self.es.delete(index=INDEX_NAME, doc_type=DOC_TYPE, id=1, ignore=(401, 404))
-        self.assertFalse(target_doc.get('found'))
+    def test_should_not_raise_exception_when_delete_nonindexed_document_if_ignored_list(
+        self,
+    ):
+        target_doc = self.es.delete(
+            index=INDEX_NAME, doc_type=DOC_TYPE, id=1, ignore=(401, 404)
+        )
+        self.assertFalse(target_doc.get("found"))
 
     def test_should_delete_indexed_document(self):
         doc_indexed = self.es.index(index=INDEX_NAME, doc_type=DOC_TYPE, body=BODY)
         search = self.es.search(index=INDEX_NAME)
-        self.assertEqual(1, search.get('hits').get('total').get('value'))
+        self.assertEqual(1, search.get("hits").get("total").get("value"))
 
-        doc_id = doc_indexed.get('_id')
+        doc_id = doc_indexed.get("_id")
         doc_deleted = self.es.delete(index=INDEX_NAME, doc_type=DOC_TYPE, id=doc_id)
         search = self.es.search(index=INDEX_NAME)
-        self.assertEqual(0, search.get('hits').get('total').get('value'))
+        self.assertEqual(0, search.get("hits").get("total").get("value"))
 
         expected_doc_deleted = {
-            'found': True,
-            '_index': INDEX_NAME,
-            '_type': DOC_TYPE,
-            '_id': doc_id,
-            '_version': 1,
+            "found": True,
+            "_index": INDEX_NAME,
+            "_type": DOC_TYPE,
+            "_id": doc_id,
+            "_version": 1,
         }
 
         self.assertDictEqual(expected_doc_deleted, doc_deleted)

--- a/tests/fake_elasticsearch/test_exists.py
+++ b/tests/fake_elasticsearch/test_exists.py
@@ -4,11 +4,12 @@ from tests import TestElasticmock, INDEX_NAME, DOC_TYPE, BODY
 
 
 class TestExists(TestElasticmock):
-
     def test_should_return_exists_false_if_nonindexed_id_is_used(self):
         self.assertFalse(self.es.exists(index=INDEX_NAME, doc_type=DOC_TYPE, id=1))
 
     def test_should_return_exists_true_if_indexed_id_is_used(self):
         data = self.es.index(index=INDEX_NAME, doc_type=DOC_TYPE, body=BODY)
-        document_id = data.get('_id')
-        self.assertTrue(self.es.exists(index=INDEX_NAME, doc_type=DOC_TYPE, id=document_id))
+        document_id = data.get("_id")
+        self.assertTrue(
+            self.es.exists(index=INDEX_NAME, doc_type=DOC_TYPE, id=document_id)
+        )

--- a/tests/fake_elasticsearch/test_get.py
+++ b/tests/fake_elasticsearch/test_get.py
@@ -6,32 +6,35 @@ from tests import TestElasticmock, INDEX_NAME, DOC_TYPE, BODY
 
 
 class TestGet(TestElasticmock):
-
     def test_should_raise_notfounderror_when_nonindexed_id_is_used(self):
         with self.assertRaises(NotFoundError):
-            self.es.get(index=INDEX_NAME, id='1')
+            self.es.get(index=INDEX_NAME, id="1")
 
-    def test_should_not_raise_notfounderror_when_nonindexed_id_is_used_and_ignored(self):
-        target_doc = self.es.get(index=INDEX_NAME, id='1', ignore=404)
-        self.assertFalse(target_doc.get('found'))
+    def test_should_not_raise_notfounderror_when_nonindexed_id_is_used_and_ignored(
+        self,
+    ):
+        target_doc = self.es.get(index=INDEX_NAME, id="1", ignore=404)
+        self.assertFalse(target_doc.get("found"))
 
-    def test_should_not_raise_notfounderror_when_nonindexed_id_is_used_and_ignored_list(self):
-        target_doc = self.es.get(index=INDEX_NAME, id='1', ignore=(401, 404))
-        self.assertFalse(target_doc.get('found'))
+    def test_should_not_raise_notfounderror_when_nonindexed_id_is_used_and_ignored_list(
+        self,
+    ):
+        target_doc = self.es.get(index=INDEX_NAME, id="1", ignore=(401, 404))
+        self.assertFalse(target_doc.get("found"))
 
     def test_should_get_document_with_id(self):
         data = self.es.index(index=INDEX_NAME, doc_type=DOC_TYPE, body=BODY)
 
-        document_id = data.get('_id')
+        document_id = data.get("_id")
         target_doc = self.es.get(index=INDEX_NAME, id=document_id)
 
         expected = {
-            '_type': DOC_TYPE,
-            '_source': BODY,
-            '_index': INDEX_NAME,
-            '_version': 1,
-            'found': True,
-            '_id': document_id
+            "_type": DOC_TYPE,
+            "_source": BODY,
+            "_index": INDEX_NAME,
+            "_version": 1,
+            "found": True,
+            "_id": document_id,
         }
 
         self.assertDictEqual(expected, target_doc)
@@ -39,16 +42,16 @@ class TestGet(TestElasticmock):
     def test_should_get_document_with_id_and_doc_type(self):
         data = self.es.index(index=INDEX_NAME, doc_type=DOC_TYPE, body=BODY)
 
-        document_id = data.get('_id')
+        document_id = data.get("_id")
         target_doc = self.es.get(index=INDEX_NAME, id=document_id, doc_type=DOC_TYPE)
 
         expected = {
-            '_type': DOC_TYPE,
-            '_source': BODY,
-            '_index': INDEX_NAME,
-            '_version': 1,
-            'found': True,
-            '_id': document_id
+            "_type": DOC_TYPE,
+            "_source": BODY,
+            "_index": INDEX_NAME,
+            "_version": 1,
+            "found": True,
+            "_id": document_id,
         }
 
         self.assertDictEqual(expected, target_doc)
@@ -56,8 +59,10 @@ class TestGet(TestElasticmock):
     def test_should_get_only_document_source_with_id(self):
         data = self.es.index(index=INDEX_NAME, doc_type=DOC_TYPE, body=BODY)
 
-        document_id = data.get('_id')
-        target_doc_source = self.es.get_source(index=INDEX_NAME, doc_type=DOC_TYPE, id=document_id)
+        document_id = data.get("_id")
+        target_doc_source = self.es.get_source(
+            index=INDEX_NAME, doc_type=DOC_TYPE, id=document_id
+        )
 
         self.assertEqual(target_doc_source, BODY)
 
@@ -65,6 +70,6 @@ class TestGet(TestElasticmock):
         ids = []
         for _ in range(0, 10):
             data = self.es.index(index=INDEX_NAME, doc_type=DOC_TYPE, body=BODY)
-            ids.append(data.get('_id'))
-        results = self.es.mget(index=INDEX_NAME, body={'ids': ids})
-        self.assertEqual(len(results['docs']), 10)
+            ids.append(data.get("_id"))
+        results = self.es.mget(index=INDEX_NAME, body={"ids": ids})
+        self.assertEqual(len(results["docs"]), 10)

--- a/tests/fake_elasticsearch/test_index.py
+++ b/tests/fake_elasticsearch/test_index.py
@@ -2,32 +2,28 @@
 
 from tests import TestElasticmock, INDEX_NAME, DOC_TYPE, BODY
 
-UPDATED_BODY = {
-    'author': 'vrcmarcos',
-    'text': 'Updated Text'
-}
+UPDATED_BODY = {"author": "vrcmarcos", "text": "Updated Text"}
 
 
 class TestIndex(TestElasticmock):
-
     def test_should_index_document(self):
         data = self.es.index(index=INDEX_NAME, doc_type=DOC_TYPE, body=BODY)
 
-        self.assertEqual(DOC_TYPE, data.get('_type'))
-        self.assertTrue(data.get('created'))
-        self.assertEqual(1, data.get('_version'))
-        self.assertEqual(INDEX_NAME, data.get('_index'))
+        self.assertEqual(DOC_TYPE, data.get("_type"))
+        self.assertTrue(data.get("created"))
+        self.assertEqual(1, data.get("_version"))
+        self.assertEqual(INDEX_NAME, data.get("_index"))
 
     def test_should_index_document_without_doc_type(self):
         data = self.es.index(index=INDEX_NAME, body=BODY)
 
-        self.assertEqual('_doc', data.get('_type'))
-        self.assertTrue(data.get('created'))
-        self.assertEqual(1, data.get('_version'))
-        self.assertEqual(INDEX_NAME, data.get('_index'))
+        self.assertEqual("_doc", data.get("_type"))
+        self.assertTrue(data.get("created"))
+        self.assertEqual(1, data.get("_version"))
+        self.assertEqual(INDEX_NAME, data.get("_index"))
 
     def test_doc_type_can_be_list(self):
-        doc_types = ['1_idx', '2_idx', '3_idx']
+        doc_types = ["1_idx", "2_idx", "3_idx"]
         count_per_doc_type = 3
 
         for doc_type in doc_types:
@@ -35,24 +31,30 @@ class TestIndex(TestElasticmock):
                 self.es.index(index=INDEX_NAME, doc_type=doc_type, body={})
 
         result = self.es.search(doc_type=[doc_types[0]])
-        self.assertEqual(count_per_doc_type, result.get('hits').get('total').get('value'))
+        self.assertEqual(
+            count_per_doc_type, result.get("hits").get("total").get("value")
+        )
 
         result = self.es.search(doc_type=doc_types[:2])
-        self.assertEqual(count_per_doc_type * 2, result.get('hits').get('total').get('value'))
+        self.assertEqual(
+            count_per_doc_type * 2, result.get("hits").get("total").get("value")
+        )
 
     def test_update_existing_doc(self):
         data = self.es.index(index=INDEX_NAME, doc_type=DOC_TYPE, body=BODY)
-        document_id = data.get('_id')
-        self.es.index(index=INDEX_NAME, id=document_id, doc_type=DOC_TYPE, body=UPDATED_BODY)
+        document_id = data.get("_id")
+        self.es.index(
+            index=INDEX_NAME, id=document_id, doc_type=DOC_TYPE, body=UPDATED_BODY
+        )
         target_doc = self.es.get(index=INDEX_NAME, id=document_id)
 
         expected = {
-            '_type': DOC_TYPE,
-            '_source': UPDATED_BODY,
-            '_index': INDEX_NAME,
-            '_version': 2,
-            'found': True,
-            '_id': document_id
+            "_type": DOC_TYPE,
+            "_source": UPDATED_BODY,
+            "_index": INDEX_NAME,
+            "_version": 2,
+            "found": True,
+            "_id": document_id,
         }
 
         self.assertDictEqual(expected, target_doc)

--- a/tests/fake_elasticsearch/test_info.py
+++ b/tests/fake_elasticsearch/test_info.py
@@ -4,7 +4,6 @@ from tests import TestElasticmock
 
 
 class TestInfo(TestElasticmock):
-
     def test_should_return_status_200_for_info(self):
         info = self.es.info()
-        self.assertEqual(info.get('status'), 200)
+        self.assertEqual(info.get("status"), 200)

--- a/tests/fake_elasticsearch/test_instance.py
+++ b/tests/fake_elasticsearch/test_instance.py
@@ -8,12 +8,13 @@ from tests import TestElasticmock
 
 
 class TestInstance(TestElasticmock):
-
     def test_should_create_fake_elasticsearch_instance(self):
         self.assertIsInstance(self.es, FakeElasticsearch)
 
     @elasticmock
-    def test_should_return_same_elastic_instance_when_instantiate_more_than_one_instance_with_same_host(self):
-        es1 = elasticsearch.Elasticsearch(hosts=[{'host': 'localhost', 'port': 9200}])
-        es2 = elasticsearch.Elasticsearch(hosts=[{'host': 'localhost', 'port': 9200}])
+    def test_should_return_same_elastic_instance_when_instantiate_more_than_one_instance_with_same_host(
+        self,
+    ):
+        es1 = elasticsearch.Elasticsearch(hosts=[{"host": "localhost", "port": 9200}])
+        es2 = elasticsearch.Elasticsearch(hosts=[{"host": "localhost", "port": 9200}])
         self.assertEqual(es1, es2)

--- a/tests/fake_elasticsearch/test_ping.py
+++ b/tests/fake_elasticsearch/test_ping.py
@@ -4,6 +4,5 @@ from tests import TestElasticmock
 
 
 class TestPing(TestElasticmock):
-
     def test_should_return_true_when_ping(self):
         self.assertTrue(self.es.ping())

--- a/tests/fake_elasticsearch/test_scroll.py
+++ b/tests/fake_elasticsearch/test_scroll.py
@@ -4,24 +4,23 @@ from tests import TestElasticmock, INDEX_NAME, DOC_TYPE, BODY
 
 
 class TestScroll(TestElasticmock):
-
     def test_scrolling(self):
         for _ in range(100):
             self.es.index(index=INDEX_NAME, doc_type=DOC_TYPE, body=BODY)
 
-        result = self.es.search(index=INDEX_NAME, params={'scroll': '1m', 'size': 30})
+        result = self.es.search(index=INDEX_NAME, params={"scroll": "1m", "size": 30})
         self.__assert_scroll(result, 30)
 
         for _ in range(2):
-            result = self.es.scroll(scroll_id=result.get('_scroll_id'), scroll='1m')
+            result = self.es.scroll(scroll_id=result.get("_scroll_id"), scroll="1m")
             self.__assert_scroll(result, 30)
 
-        result = self.es.scroll(scroll_id=result.get('_scroll_id'), scroll='1m')
+        result = self.es.scroll(scroll_id=result.get("_scroll_id"), scroll="1m")
         self.__assert_scroll(result, 10)
 
     def __assert_scroll(self, result, expected_scroll_hits):
-        hits = result.get('hits')
+        hits = result.get("hits")
 
-        self.assertNotEqual(None, result.get('_scroll_id', None))
-        self.assertEqual(expected_scroll_hits, len(hits.get('hits')))
-        self.assertEqual(100, hits.get('total').get('value'))
+        self.assertNotEqual(None, result.get("_scroll_id", None))
+        self.assertEqual(expected_scroll_hits, len(hits.get("hits")))
+        self.assertEqual(100, hits.get("total").get("value"))

--- a/tests/fake_elasticsearch/test_search.py
+++ b/tests/fake_elasticsearch/test_search.py
@@ -8,336 +8,433 @@ from tests import TestElasticmock, INDEX_NAME, DOC_TYPE
 
 
 class TestSearch(TestElasticmock):
-
     def test_should_raise_notfounderror_when_search_for_unexistent_index(self):
         with self.assertRaises(NotFoundError):
             self.es.search(index=INDEX_NAME)
 
     def test_should_return_hits_hits_even_when_no_result(self):
         search = self.es.search()
-        self.assertEqual(0, search.get('hits').get('total').get('value'))
-        self.assertListEqual([], search.get('hits').get('hits'))
+        self.assertEqual(0, search.get("hits").get("total").get("value"))
+        self.assertListEqual([], search.get("hits").get("hits"))
 
     def test_should_return_skipped_shards(self):
         search = self.es.search()
-        self.assertEqual(0, search.get('_shards').get('skipped'))
+        self.assertEqual(0, search.get("_shards").get("skipped"))
 
     def test_should_return_all_documents(self):
         index_quantity = 10
         for i in range(0, index_quantity):
-            self.es.index(index='index_{0}'.format(i), doc_type=DOC_TYPE, body={'data': 'test_{0}'.format(i)})
+            self.es.index(
+                index="index_{0}".format(i),
+                doc_type=DOC_TYPE,
+                body={"data": "test_{0}".format(i)},
+            )
 
         search = self.es.search()
-        self.assertEqual(index_quantity, search.get('hits').get('total').get('value'))
+        self.assertEqual(index_quantity, search.get("hits").get("total").get("value"))
 
     def test_should_return_all_documents_match_all(self):
         index_quantity = 10
         for i in range(0, index_quantity):
-            self.es.index(index='index_{0}'.format(i), doc_type=DOC_TYPE, body={'data': 'test_{0}'.format(i)})
+            self.es.index(
+                index="index_{0}".format(i),
+                doc_type=DOC_TYPE,
+                body={"data": "test_{0}".format(i)},
+            )
 
-        search = self.es.search(body={'query': {'match_all': {}}})
-        self.assertEqual(index_quantity, search.get('hits').get('total').get('value'))
+        search = self.es.search(body={"query": {"match_all": {}}})
+        self.assertEqual(index_quantity, search.get("hits").get("total").get("value"))
 
     def test_should_return_only_indexed_documents_on_index(self):
         index_quantity = 2
         for i in range(0, index_quantity):
-            self.es.index(index=INDEX_NAME, doc_type=DOC_TYPE, body={'data': 'test_{0}'.format(i)})
+            self.es.index(
+                index=INDEX_NAME, doc_type=DOC_TYPE, body={"data": "test_{0}".format(i)}
+            )
 
         search = self.es.search(index=INDEX_NAME)
-        self.assertEqual(index_quantity, search.get('hits').get('total').get('value'))
+        self.assertEqual(index_quantity, search.get("hits").get("total").get("value"))
 
     def test_should_return_only_indexed_documents_on_index_with_doc_type(self):
         index_quantity = 2
         for i in range(0, index_quantity):
-            self.es.index(index=INDEX_NAME, doc_type=DOC_TYPE, body={'data': 'test_{0}'.format(i)})
-        self.es.index(index=INDEX_NAME, doc_type='another-Doctype', body={'data': 'test'})
+            self.es.index(
+                index=INDEX_NAME, doc_type=DOC_TYPE, body={"data": "test_{0}".format(i)}
+            )
+        self.es.index(
+            index=INDEX_NAME, doc_type="another-Doctype", body={"data": "test"}
+        )
 
         search = self.es.search(index=INDEX_NAME, doc_type=DOC_TYPE)
-        self.assertEqual(index_quantity, search.get('hits').get('total').get('value'))
+        self.assertEqual(index_quantity, search.get("hits").get("total").get("value"))
 
     def test_should_search_in_multiple_indexes(self):
-        self.es.index(index='groups', doc_type='groups', body={'budget': 1000})
-        self.es.index(index='users', doc_type='users', body={'name': 'toto'})
-        self.es.index(index='pcs', doc_type='pcs', body={'model': 'macbook'})
+        self.es.index(index="groups", doc_type="groups", body={"budget": 1000})
+        self.es.index(index="users", doc_type="users", body={"name": "toto"})
+        self.es.index(index="pcs", doc_type="pcs", body={"model": "macbook"})
 
-        result = self.es.search(index=['users', 'pcs'])
-        self.assertEqual(2, result.get('hits').get('total').get('value'))
+        result = self.es.search(index=["users", "pcs"])
+        self.assertEqual(2, result.get("hits").get("total").get("value"))
 
     def test_usage_of_aggregations(self):
-        self.es.index(index='index', doc_type='document', body={'genre': 'rock'})
+        self.es.index(index="index", doc_type="document", body={"genre": "rock"})
 
         body = {"aggs": {"genres": {"terms": {"field": "genre"}}}}
-        result = self.es.search(index='index', body=body)
+        result = self.es.search(index="index", body=body)
 
-        self.assertTrue('aggregations' in result)
+        self.assertTrue("aggregations" in result)
 
     def test_search_with_scroll_param(self):
         for _ in range(100):
-            self.es.index(index='groups', doc_type='groups', body={'budget': 1000})
+            self.es.index(index="groups", doc_type="groups", body={"budget": 1000})
 
-        result = self.es.search(index='groups', params={'scroll': '1m', 'size': 30})
-        self.assertNotEqual(None, result.get('_scroll_id', None))
-        self.assertEqual(30, len(result.get('hits').get('hits')))
-        self.assertEqual(100, result.get('hits').get('total').get('value'))
+        result = self.es.search(index="groups", params={"scroll": "1m", "size": 30})
+        self.assertNotEqual(None, result.get("_scroll_id", None))
+        self.assertEqual(30, len(result.get("hits").get("hits")))
+        self.assertEqual(100, result.get("hits").get("total").get("value"))
 
     def test_search_with_match_query(self):
         for i in range(0, 10):
-            self.es.index(index='index_for_search', doc_type=DOC_TYPE, body={'data': 'test_{0}'.format(i)})
+            self.es.index(
+                index="index_for_search",
+                doc_type=DOC_TYPE,
+                body={"data": "test_{0}".format(i)},
+            )
 
-        response = self.es.search(index='index_for_search', doc_type=DOC_TYPE,
-                                  body={'query': {'match': {'data': 'TEST'}}})
-        self.assertEqual(response['hits']['total']['value'], 10)
-        hits = response['hits']['hits']
+        response = self.es.search(
+            index="index_for_search",
+            doc_type=DOC_TYPE,
+            body={"query": {"match": {"data": "TEST"}}},
+        )
+        self.assertEqual(response["hits"]["total"]["value"], 10)
+        hits = response["hits"]["hits"]
         self.assertEqual(len(hits), 10)
 
-        response = self.es.search(index='index_for_search', doc_type=DOC_TYPE, body={'query': {'match': {'data': '3'}}})
-        self.assertEqual(response['hits']['total']['value'], 1)
-        hits = response['hits']['hits']
+        response = self.es.search(
+            index="index_for_search",
+            doc_type=DOC_TYPE,
+            body={"query": {"match": {"data": "3"}}},
+        )
+        self.assertEqual(response["hits"]["total"]["value"], 1)
+        hits = response["hits"]["hits"]
         self.assertEqual(len(hits), 1)
-        self.assertEqual(hits[0]['_source'], {'data': 'test_3'})
+        self.assertEqual(hits[0]["_source"], {"data": "test_3"})
 
     def test_search_with_match_query_in_int_list(self):
         for i in range(0, 10):
-            self.es.index(index='index_for_search', doc_type=DOC_TYPE, body={'data': [i, 11, 13]})
-        response = self.es.search(index='index_for_search', doc_type=DOC_TYPE, body={'query': {'match': {'data': 1}}})
-        self.assertEqual(response['hits']['total']['value'], 1)
-        hits = response['hits']['hits']
+            self.es.index(
+                index="index_for_search", doc_type=DOC_TYPE, body={"data": [i, 11, 13]}
+            )
+        response = self.es.search(
+            index="index_for_search",
+            doc_type=DOC_TYPE,
+            body={"query": {"match": {"data": 1}}},
+        )
+        self.assertEqual(response["hits"]["total"]["value"], 1)
+        hits = response["hits"]["hits"]
         self.assertEqual(len(hits), 1)
-        self.assertEqual(hits[0]['_source'], {'data': [1, 11, 13]})
+        self.assertEqual(hits[0]["_source"], {"data": [1, 11, 13]})
 
     def test_search_with_match_query_in_string_list(self):
         for i in range(0, 10):
-            self.es.index(index='index_for_search', doc_type=DOC_TYPE, body={'data': [str(i), 'two', 'three']})
+            self.es.index(
+                index="index_for_search",
+                doc_type=DOC_TYPE,
+                body={"data": [str(i), "two", "three"]},
+            )
 
-        response = self.es.search(index='index_for_search', doc_type=DOC_TYPE, body={'query': {'match': {'data': '1'}}})
-        self.assertEqual(response['hits']['total']['value'], 1)
-        hits = response['hits']['hits']
+        response = self.es.search(
+            index="index_for_search",
+            doc_type=DOC_TYPE,
+            body={"query": {"match": {"data": "1"}}},
+        )
+        self.assertEqual(response["hits"]["total"]["value"], 1)
+        hits = response["hits"]["hits"]
         self.assertEqual(len(hits), 1)
-        self.assertEqual(hits[0]['_source'], {'data': ['1', 'two', 'three']})
+        self.assertEqual(hits[0]["_source"], {"data": ["1", "two", "three"]})
 
     def test_search_with_term_query(self):
         for i in range(0, 10):
-            self.es.index(index='index_for_search', doc_type=DOC_TYPE, body={'data': 'test_{0}'.format(i)})
+            self.es.index(
+                index="index_for_search",
+                doc_type=DOC_TYPE,
+                body={"data": "test_{0}".format(i)},
+            )
 
-        response = self.es.search(index='index_for_search', doc_type=DOC_TYPE,
-                                  body={'query': {'term': {'data': 'TEST'}}})
-        self.assertEqual(response['hits']['total']['value'], 0)
-        hits = response['hits']['hits']
+        response = self.es.search(
+            index="index_for_search",
+            doc_type=DOC_TYPE,
+            body={"query": {"term": {"data": "TEST"}}},
+        )
+        self.assertEqual(response["hits"]["total"]["value"], 0)
+        hits = response["hits"]["hits"]
         self.assertEqual(len(hits), 0)
 
-        response = self.es.search(index='index_for_search', doc_type=DOC_TYPE, body={'query': {'term': {'data': '3'}}})
-        self.assertEqual(response['hits']['total']['value'], 1)
-        hits = response['hits']['hits']
+        response = self.es.search(
+            index="index_for_search",
+            doc_type=DOC_TYPE,
+            body={"query": {"term": {"data": "3"}}},
+        )
+        self.assertEqual(response["hits"]["total"]["value"], 1)
+        hits = response["hits"]["hits"]
         self.assertEqual(len(hits), 1)
-        self.assertEqual(hits[0]['_source'], {'data': 'test_3'})
+        self.assertEqual(hits[0]["_source"], {"data": "test_3"})
 
     def test_search_with_bool_query(self):
         for i in range(0, 10):
-            self.es.index(index='index_for_search', doc_type=DOC_TYPE, body={'id': i})
+            self.es.index(index="index_for_search", doc_type=DOC_TYPE, body={"id": i})
 
-        response = self.es.search(index='index_for_search', doc_type=DOC_TYPE,
-                                  body={'query': {'bool': {'filter': [{'term': {'id': 1}}]}}})
-        self.assertEqual(response['hits']['total']['value'], 1)
-        hits = response['hits']['hits']
+        response = self.es.search(
+            index="index_for_search",
+            doc_type=DOC_TYPE,
+            body={"query": {"bool": {"filter": [{"term": {"id": 1}}]}}},
+        )
+        self.assertEqual(response["hits"]["total"]["value"], 1)
+        hits = response["hits"]["hits"]
         self.assertEqual(len(hits), 1)
 
     def test_search_with_must_not_query(self):
         for i in range(0, 10):
-            self.es.index(index='index_for_search', doc_type=DOC_TYPE, body={'id': i})
-        response = self.es.search(index='index_for_search', doc_type=DOC_TYPE,
-                                  body={'query': {'bool': {
-                                      'filter': [{'terms': {'id': [1, 2]}}],
-                                      'must_not': [{'term': {'id': 1}}],
-                                      }}})
-        self.assertEqual(response['hits']['total']['value'], 1)
-        doc = response['hits']['hits'][0]['_source']
-        self.assertEqual(2, doc['id'])
+            self.es.index(index="index_for_search", doc_type=DOC_TYPE, body={"id": i})
+        response = self.es.search(
+            index="index_for_search",
+            doc_type=DOC_TYPE,
+            body={
+                "query": {
+                    "bool": {
+                        "filter": [{"terms": {"id": [1, 2]}}],
+                        "must_not": [{"term": {"id": 1}}],
+                    }
+                }
+            },
+        )
+        self.assertEqual(response["hits"]["total"]["value"], 1)
+        doc = response["hits"]["hits"][0]["_source"]
+        self.assertEqual(2, doc["id"])
 
     def test_search_with_terms_query(self):
         for i in range(0, 10):
-            self.es.index(index='index_for_search', doc_type=DOC_TYPE, body={'id': i})
+            self.es.index(index="index_for_search", doc_type=DOC_TYPE, body={"id": i})
 
-        response = self.es.search(index='index_for_search', doc_type=DOC_TYPE,
-                                  body={'query': {'terms': {'id': [1, 2, 3]}}})
-        self.assertEqual(response['hits']['total']['value'], 3)
-        hits = response['hits']['hits']
+        response = self.es.search(
+            index="index_for_search",
+            doc_type=DOC_TYPE,
+            body={"query": {"terms": {"id": [1, 2, 3]}}},
+        )
+        self.assertEqual(response["hits"]["total"]["value"], 3)
+        hits = response["hits"]["hits"]
         self.assertEqual(len(hits), 3)
 
     def test_query_on_nested_data(self):
-        for i, y in enumerate(['yes', 'no']):
-            self.es.index('index_for_search', doc_type=DOC_TYPE,
-                          body={'id': i, 'data': {'x': i, 'y': y}})
+        for i, y in enumerate(["yes", "no"]):
+            self.es.index(
+                "index_for_search",
+                doc_type=DOC_TYPE,
+                body={"id": i, "data": {"x": i, "y": y}},
+            )
 
-        for term, value, i in [('data.x', 1, 1), ('data.y', 'yes', 0)]:
-            response = self.es.search(index='index_for_search', doc_type=DOC_TYPE,
-                                      body={'query': {'term': {term: value}}})
-            self.assertEqual(1, response['hits']['total']['value'])
-            doc = response['hits']['hits'][0]['_source']
-            self.assertEqual(i, doc['id'])
-
+        for term, value, i in [("data.x", 1, 1), ("data.y", "yes", 0)]:
+            response = self.es.search(
+                index="index_for_search",
+                doc_type=DOC_TYPE,
+                body={"query": {"term": {term: value}}},
+            )
+            self.assertEqual(1, response["hits"]["total"]["value"])
+            doc = response["hits"]["hits"][0]["_source"]
+            self.assertEqual(i, doc["id"])
 
     def test_search_with_bool_query_and_multi_match(self):
         for i in range(0, 10):
-            self.es.index(index='index_for_search', doc_type=DOC_TYPE, body={
-                'data': 'test_{0}'.format(i) if i % 2 == 0 else None,
-                'data2': 'test_{0}'.format(i) if (i+1) % 2 == 0 else None
-                })
+            self.es.index(
+                index="index_for_search",
+                doc_type=DOC_TYPE,
+                body={
+                    "data": "test_{0}".format(i) if i % 2 == 0 else None,
+                    "data2": "test_{0}".format(i) if (i + 1) % 2 == 0 else None,
+                },
+            )
 
         search_body = {
             "query": {
                 "bool": {
                     "must": {
-                        "multi_match": {
-                            "query": "test",
-                            "fields": ["data", "data2"]
-                        }
+                        "multi_match": {"query": "test", "fields": ["data", "data2"]}
                     }
                 }
             }
         }
-        response = self.es.search(index='index_for_search', doc_type=DOC_TYPE,
-                                  body=search_body)
-        self.assertEqual(response['hits']['total']['value'], 10)
-        hits = response['hits']['hits']
+        response = self.es.search(
+            index="index_for_search", doc_type=DOC_TYPE, body=search_body
+        )
+        self.assertEqual(response["hits"]["total"]["value"], 10)
+        hits = response["hits"]["hits"]
         self.assertEqual(len(hits), 10)
 
     def test_search_bool_should_match_query(self):
         for i in range(0, 10):
-            self.es.index(index='index_for_search', doc_type=DOC_TYPE, body={'data': 'test_{0}'.format(i)})
+            self.es.index(
+                index="index_for_search",
+                doc_type=DOC_TYPE,
+                body={"data": "test_{0}".format(i)},
+            )
 
-        response = self.es.search(index='index_for_search', doc_type=DOC_TYPE,
-                                  body={
-                                      'query': {
-                                          'bool': {
-                                              'should': [
-                                                  {'match': {'data': 'test_0'}},
-                                                  {'match': {'data': 'test_1'}},
-                                                  {'match': {'data': 'test_2'}},
-                                              ]
-                                          }
-                                      }
-                                  })
-        self.assertEqual(response['hits']['total']['value'], 3)
-        hits = response['hits']['hits']
+        response = self.es.search(
+            index="index_for_search",
+            doc_type=DOC_TYPE,
+            body={
+                "query": {
+                    "bool": {
+                        "should": [
+                            {"match": {"data": "test_0"}},
+                            {"match": {"data": "test_1"}},
+                            {"match": {"data": "test_2"}},
+                        ]
+                    }
+                }
+            },
+        )
+        self.assertEqual(response["hits"]["total"]["value"], 3)
+        hits = response["hits"]["hits"]
         self.assertEqual(len(hits), 3)
-        self.assertEqual(hits[0]['_source'], {'data': 'test_0'})
+        self.assertEqual(hits[0]["_source"], {"data": "test_0"})
 
     def test_msearch(self):
         for i in range(0, 10):
-            self.es.index(index='index_for_search1', doc_type=DOC_TYPE, body={
-                'data': 'test_{0}'.format(i) if i % 2 == 0 else None,
-                'data2': 'test_{0}'.format(i) if (i+1) % 2 == 0 else None
-                })
+            self.es.index(
+                index="index_for_search1",
+                doc_type=DOC_TYPE,
+                body={
+                    "data": "test_{0}".format(i) if i % 2 == 0 else None,
+                    "data2": "test_{0}".format(i) if (i + 1) % 2 == 0 else None,
+                },
+            )
         for i in range(0, 10):
-            self.es.index(index='index_for_search2', doc_type=DOC_TYPE, body={
-                'data': 'test_{0}'.format(i) if i % 2 == 0 else None,
-                'data2': 'test_{0}'.format(i) if (i+1) % 2 == 0 else None
-                })
+            self.es.index(
+                index="index_for_search2",
+                doc_type=DOC_TYPE,
+                body={
+                    "data": "test_{0}".format(i) if i % 2 == 0 else None,
+                    "data2": "test_{0}".format(i) if (i + 1) % 2 == 0 else None,
+                },
+            )
 
         search_body = {
             "query": {
                 "bool": {
                     "must": {
-                        "multi_match": {
-                            "query": "test",
-                            "fields": ["data", "data2"]
-                        }
+                        "multi_match": {"query": "test", "fields": ["data", "data2"]}
                     }
                 }
             }
         }
         body = []
-        body.append({'index': 'index_for_search1'})
+        body.append({"index": "index_for_search1"})
         body.append(search_body)
-        body.append({'index': 'index_for_search2'})
+        body.append({"index": "index_for_search2"})
         body.append(search_body)
 
-        result = self.es.msearch(index='index_for_search', body=body)
-        response1, response2 = result['responses']
-        self.assertEqual(response1['hits']['total']['value'], 10)
-        hits1 = response1['hits']['hits']
+        result = self.es.msearch(index="index_for_search", body=body)
+        response1, response2 = result["responses"]
+        self.assertEqual(response1["hits"]["total"]["value"], 10)
+        hits1 = response1["hits"]["hits"]
         self.assertEqual(len(hits1), 10)
-        self.assertEqual(response2['hits']['total']['value'], 10)
-        hits2 = response2['hits']['hits']
+        self.assertEqual(response2["hits"]["total"]["value"], 10)
+        hits2 = response2["hits"]["hits"]
         self.assertEqual(len(hits2), 10)
 
     @parameterized.expand(
         [
             (
-                    'timestamp gt',
-                    {'timestamp': {'gt': datetime.datetime(2009, 1, 1, 10, 20, 0).isoformat()}},
-                    range(5, 12),
+                "timestamp gt",
+                {
+                    "timestamp": {
+                        "gt": datetime.datetime(2009, 1, 1, 10, 20, 0).isoformat()
+                    }
+                },
+                range(5, 12),
             ),
             (
-                    'timestamp gte',
-                    {'timestamp': {'gte': datetime.datetime(2009, 1, 1, 10, 20, 0).isoformat()}},
-                    range(4, 12),
+                "timestamp gte",
+                {
+                    "timestamp": {
+                        "gte": datetime.datetime(2009, 1, 1, 10, 20, 0).isoformat()
+                    }
+                },
+                range(4, 12),
             ),
             (
-                    'timestamp lt',
-                    {'timestamp': {'lt': datetime.datetime(2009, 1, 1, 10, 35, 0).isoformat()}},
-                    range(7),
+                "timestamp lt",
+                {
+                    "timestamp": {
+                        "lt": datetime.datetime(2009, 1, 1, 10, 35, 0).isoformat()
+                    }
+                },
+                range(7),
             ),
             (
-                    'timestamp lte',
-                    {'timestamp': {'lte': datetime.datetime(2009, 1, 1, 10, 35, 0).isoformat()}},
-                    range(8),
+                "timestamp lte",
+                {
+                    "timestamp": {
+                        "lte": datetime.datetime(2009, 1, 1, 10, 35, 0).isoformat()
+                    }
+                },
+                range(8),
             ),
             (
-                    'timestamp combination',
-                    {
-                        'timestamp': {
-                            'gt': datetime.datetime(2009, 1, 1, 10, 15, 0).isoformat(),
-                            'lte': datetime.datetime(2009, 1, 1, 10, 35, 0).isoformat(),
-                        }
-                    },
-                    range(4, 8),
+                "timestamp combination",
+                {
+                    "timestamp": {
+                        "gt": datetime.datetime(2009, 1, 1, 10, 15, 0).isoformat(),
+                        "lte": datetime.datetime(2009, 1, 1, 10, 35, 0).isoformat(),
+                    }
+                },
+                range(4, 8),
             ),
             (
-                    'data_int gt',
-                    {'data_int': {'gt': 40}},
-                    range(5, 12),
+                "data_int gt",
+                {"data_int": {"gt": 40}},
+                range(5, 12),
             ),
             (
-                    'data_int gte',
-                    {'data_int': {'gte': 40}},
-                    range(4, 12),
+                "data_int gte",
+                {"data_int": {"gte": 40}},
+                range(4, 12),
             ),
             (
-                    'data_int lt',
-                    {'data_int': {'lt': 70}},
-                    range(7),
+                "data_int lt",
+                {"data_int": {"lt": 70}},
+                range(7),
             ),
             (
-                    'data_int lte',
-                    {'data_int': {'lte': 70}},
-                    range(8),
+                "data_int lte",
+                {"data_int": {"lte": 70}},
+                range(8),
             ),
             (
-                    'data_int combination',
-                    {'data_int': {'gt': 30, 'lte': 70}},
-                    range(4, 8),
+                "data_int combination",
+                {"data_int": {"gt": 30, "lte": 70}},
+                range(4, 8),
             ),
         ]
     )
     def test_search_with_range_query(self, _, query_range, expected_ids):
         for i in range(0, 12):
             body = {
-                'id': i,
-                'timestamp': datetime.datetime(2009, 1, 1, 10, 5 * i, 0),
-                'data_int': 10 * i,
+                "id": i,
+                "timestamp": datetime.datetime(2009, 1, 1, 10, 5 * i, 0),
+                "data_int": 10 * i,
             }
-            self.es.index(index='index_for_search', doc_type=DOC_TYPE, body=body)
+            self.es.index(index="index_for_search", doc_type=DOC_TYPE, body=body)
 
         response = self.es.search(
-            index='index_for_search',
+            index="index_for_search",
             doc_type=DOC_TYPE,
-            body={'query': {'range': query_range}},
+            body={"query": {"range": query_range}},
         )
 
-        self.assertEqual(len(expected_ids), response['hits']['total']['value'])
-        hits = response['hits']['hits']
-        self.assertEqual(set(expected_ids), set(hit['_source']['id'] for hit in hits))
+        self.assertEqual(len(expected_ids), response["hits"]["total"]["value"])
+        hits = response["hits"]["hits"]
+        self.assertEqual(set(expected_ids), set(hit["_source"]["id"] for hit in hits))
 
     def test_bucket_aggregation(self):
         data = [
@@ -348,7 +445,7 @@ class TestSearch(TestElasticmock):
             {"data_x": 3, "data_y": "b"},
         ]
         for body in data:
-            self.es.index(index='index_for_search', doc_type=DOC_TYPE, body=body)
+            self.es.index(index="index_for_search", doc_type=DOC_TYPE, body=body)
 
         response = self.es.search(
             index="index_for_search",

--- a/tests/fake_elasticsearch/test_suggest.py
+++ b/tests/fake_elasticsearch/test_suggest.py
@@ -6,7 +6,6 @@ from tests import TestElasticmock, INDEX_NAME, DOC_TYPE, BODY
 
 
 class TestSuggest(TestElasticmock):
-
     def test_should_raise_notfounderror_when_nonindexed_id_is_used_for_suggest(self):
         with self.assertRaises(NotFoundError):
             self.es.suggest(body={}, index=INDEX_NAME)
@@ -14,48 +13,31 @@ class TestSuggest(TestElasticmock):
     def test_should_return_suggestions(self):
         self.es.index(index=INDEX_NAME, doc_type=DOC_TYPE, body=BODY)
         suggestion_body = {
-            'suggestion-string': {
-                'text': 'test_text',
-                'term': {
-                    'field': 'string'
-                }
-            },
-            'suggestion-id': {
-                'text': 1234567,
-                'term': {
-                    'field': 'id'
-                }
-            }
+            "suggestion-string": {"text": "test_text", "term": {"field": "string"}},
+            "suggestion-id": {"text": 1234567, "term": {"field": "id"}},
         }
         suggestion = self.es.suggest(body=suggestion_body, index=INDEX_NAME)
         self.assertIsNotNone(suggestion)
-        self.assertDictEqual({
-            'suggestion-string': [
-                {
-                    'text': 'test_text',
-                    'length': 1,
-                    'options': [
-                        {
-                            'text': 'test_text_suggestion',
-                            'freq': 1,
-                            'score': 1.0
-                        }
-                    ],
-                    'offset': 0
-                }
-            ],
-            'suggestion-id': [
-                {
-                    'text': 1234567,
-                    'length': 1,
-                    'options': [
-                        {
-                            'text': 1234568,
-                            'freq': 1,
-                            'score': 1.0
-                        }
-                    ],
-                    'offset': 0
-                }
-            ],
-        }, suggestion)
+        self.assertDictEqual(
+            {
+                "suggestion-string": [
+                    {
+                        "text": "test_text",
+                        "length": 1,
+                        "options": [
+                            {"text": "test_text_suggestion", "freq": 1, "score": 1.0}
+                        ],
+                        "offset": 0,
+                    }
+                ],
+                "suggestion-id": [
+                    {
+                        "text": 1234567,
+                        "length": 1,
+                        "options": [{"text": 1234568, "freq": 1, "score": 1.0}],
+                        "offset": 0,
+                    }
+                ],
+            },
+            suggestion,
+        )

--- a/tests/fake_indices/test_create.py
+++ b/tests/fake_indices/test_create.py
@@ -4,7 +4,6 @@ from tests import TestElasticmock, INDEX_NAME
 
 
 class TestCreate(TestElasticmock):
-
     def test_should_create_index(self):
         self.assertFalse(self.es.indices.exists(INDEX_NAME))
         self.es.indices.create(INDEX_NAME)

--- a/tests/fake_indices/test_delete.py
+++ b/tests/fake_indices/test_delete.py
@@ -4,7 +4,6 @@ from tests import TestElasticmock, INDEX_NAME
 
 
 class TestDelete(TestElasticmock):
-
     def test_should_delete_index(self):
         self.assertFalse(self.es.indices.exists(INDEX_NAME))
 

--- a/tests/fake_indices/test_exists.py
+++ b/tests/fake_indices/test_exists.py
@@ -4,7 +4,6 @@ from tests import TestElasticmock, INDEX_NAME
 
 
 class TestExists(TestElasticmock):
-
     def test_should_return_false_when_index_does_not_exists(self):
         self.assertFalse(self.es.indices.exists(INDEX_NAME))
 

--- a/tests/fake_indices/test_refresh.py
+++ b/tests/fake_indices/test_refresh.py
@@ -4,7 +4,6 @@ from tests import TestElasticmock, INDEX_NAME
 
 
 class TestRefresh(TestElasticmock):
-
     def test_should_refresh_index(self):
         self.es.indices.create(INDEX_NAME)
         self.es.indices.refresh(INDEX_NAME)

--- a/tests/tox_banner.py
+++ b/tests/tox_banner.py
@@ -10,6 +10,6 @@ print(
     "{} {}; ElasticSearch {}".format(
         platform.python_implementation(),
         platform.python_version(),
-        elasticsearch.VERSION
+        elasticsearch.VERSION,
     )
 )

--- a/tox.ini
+++ b/tox.ini
@@ -5,12 +5,14 @@ envlist =
     py37-elasticsearch{1,2,5,6,7}
     py38-elasticsearch{1,2,5,6,7}
     py39-elasticsearch{1,2,5,6,7}
+    py27-elasticsearch{1,2,5,6,7}
 
 [testenv]
 deps =
     parameterized
     pytest==4.6.9
     pytest-cov==2.8.1
+    mock >=2.0.0, <3.0.0
     elasticsearch1: elasticsearch ==1.9.0
     elasticsearch2: elasticsearch >=2.0.0, <5.0.0
     elasticsearch5: elasticsearch >=5.0.0, <6.0.0


### PR DESCRIPTION
this only patches `elasticsearch.Elasticsearch` but if you use https://pypi.org/project/elasticsearch6/ or https://pypi.org/project/elasticsearch7/ for example, you can't mock these.