### PR TITLE
Add result key to the index result dict, add a primitive version of update_by_query and fix mget

### DIFF
--- a/elasticmock/fake_elasticsearch.py
+++ b/elasticmock/fake_elasticsearch.py
@@ -317,10 +317,12 @@ class FakeElasticsearch(Elasticsearch):
 
         if id is None:
             id = get_random_id()
+            result = 'created'
         elif self.exists(index, id, doc_type=doc_type, params=params):
             doc = self.get(index, id, doc_type=doc_type, params=params)
             version = doc['_version'] + 1
             self.delete(index, id, doc_type=doc_type)
+            result = 'updated'
 
         self.__documents_dict[index].append({
             '_type': doc_type,
@@ -335,7 +337,8 @@ class FakeElasticsearch(Elasticsearch):
             '_id': id,
             'created': True,
             '_version': version,
-            '_index': index
+            '_index': index,
+            'result': result
         }
 
     @query_params('consistency', 'op_type', 'parent', 'refresh', 'replication',

--- a/elasticmock/fake_elasticsearch.py
+++ b/elasticmock/fake_elasticsearch.py
@@ -340,9 +340,10 @@ class FakeElasticsearch(Elasticsearch):
 
         version = 1
 
+        result = 'created'
         if id is None:
             id = get_random_id()
-            result = 'created'
+
         elif self.exists(index, id, doc_type=doc_type, params=params):
             doc = self.get(index, id, doc_type=doc_type, params=params)
             version = doc['_version'] + 1

--- a/elasticmock/fake_elasticsearch.py
+++ b/elasticmock/fake_elasticsearch.py
@@ -769,6 +769,8 @@ class FakeElasticsearch(Elasticsearch):
             hits = hits[params.get('from'):params.get('from') + params.get('size')]
         elif 'size' in params:
             hits = hits[:int(params['size'])]
+        elif body and 'size' in body:
+            hits = hits[:int(body['size'])]
 
         result['hits']['hits'] = hits
 

--- a/elasticmock/fake_elasticsearch.py
+++ b/elasticmock/fake_elasticsearch.py
@@ -511,7 +511,8 @@ class FakeElasticsearch(Elasticsearch):
                   'preference', 'realtime', 'refresh', 'routing',
                   'stored_fields')
     def mget(self, body, index, doc_type='_all', params=None, headers=None):
-        ids = body.get('ids')
+        docs = body.get('docs')
+        ids = [doc['_id'] for doc in docs]
         results = []
         for id in ids:
             try:

--- a/tests/fake_elasticsearch/test_get.py
+++ b/tests/fake_elasticsearch/test_get.py
@@ -66,5 +66,5 @@ class TestGet(TestElasticmock):
         for _ in range(0, 10):
             data = self.es.index(index=INDEX_NAME, doc_type=DOC_TYPE, body=BODY)
             ids.append(data.get('_id'))
-        results = self.es.mget(index=INDEX_NAME, body={'ids': ids})
+        results = self.es.mget(index=INDEX_NAME, body={'docs': [{'_id': id} for id in ids]})
         self.assertEqual(len(results['docs']), 10)

--- a/tests/fake_elasticsearch/test_index.py
+++ b/tests/fake_elasticsearch/test_index.py
@@ -57,3 +57,22 @@ class TestIndex(TestElasticmock):
         }
 
         self.assertDictEqual(expected, target_doc)
+
+
+    def test_update_by_query(self):
+        data = self.es.index(index=INDEX_NAME, doc_type=DOC_TYPE, body=BODY)
+        document_id = data.get('_id')
+        new_author = 'kimchy2'
+        self.es.update_by_query(index=INDEX_NAME, body={
+            'query': {
+                'match': {'author': 'kimchy'},
+            },
+            'script': {
+                'source': 'ctx._source.author = params.author',
+                'params': {
+                    'author': new_author
+                }
+            }
+        })
+        target_doc = self.es.get(index=INDEX_NAME, id=document_id)
+        self.assertEqual(target_doc['_source']['author'], new_author)

--- a/tests/fake_elasticsearch/test_index.py
+++ b/tests/fake_elasticsearch/test_index.py
@@ -17,6 +17,7 @@ class TestIndex(TestElasticmock):
         self.assertTrue(data.get('created'))
         self.assertEqual(1, data.get('_version'))
         self.assertEqual(INDEX_NAME, data.get('_index'))
+        self.assertEqual('created', data.get('result'))
 
     def test_should_index_document_without_doc_type(self):
         data = self.es.index(index=INDEX_NAME, body=BODY)


### PR DESCRIPTION
Hi Marcos,
I hope you are well in these times of pandemic.

I opened this PR in order to add the key 'result' to the index result meta returned because I found it's missing, add a primitive version of update_by_query and fix mget

Best regards,
Carlos
