### PR TITLE
Require elasticsearch <8.0.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ setuptools.setup(
     url='https://github.com/vrcmarcos/elasticmock',
     packages=setuptools.find_packages(exclude=('tests')),
     install_requires=[
-        'elasticsearch',
+        'elasticsearch<8.0.0',
         'python-dateutil',
     ],
     classifiers=[


### PR DESCRIPTION
ElasticMock is not compatible with elasticsearch >=8.0.0. Limiting the version to avoid confusion.