### PR TITLE
Fix issue with mappings parameter when using django-elasticmock-dsl model init

### DIFF
--- a/elasticmock/fake_indices.py
+++ b/elasticmock/fake_indices.py
@@ -7,7 +7,7 @@ from elasticsearch.client.utils import query_params
 class FakeIndicesClient(IndicesClient):
 
     @query_params('master_timeout', 'timeout')
-    def create(self, index, body=None, params=None, headers=None):
+    def create(self, index, body=None, params=None, headers=None, *args, **kwargs):
         documents_dict = self.__get_documents_dict()
         if index not in documents_dict:
             documents_dict[index] = []


### PR DESCRIPTION
I encountered an issue when attempting to initialize a document model using the mappings parameter in the `MyDocumentModel.init()` method from `django-elasticsearch-dsl`. 

Specifically, I received a TypeError indicating that the `create()` method was not expecting the mappings argument. I believe this issue may be related to the elasticmock library, as I am not experiencing this problem when using a real Elasticsearch instance. 

As such, I have opened this PR to investigate the issue and propose a solution if possible.